### PR TITLE
fix(Sidebar) link for sidebar with "." works FTI-1707

### DIFF
--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -57,7 +57,7 @@ export default class SidebarList extends React.Component {
       .replace(/\//g, '_')
       .replace(/-/, '_')
       .replace(/\s/g, '_')
-      .replace(/\./, '\\.')
+      .replace(/\./g, '\\.')
   }
 
   moveToAnchor(destination) {

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -57,7 +57,7 @@ export default class SidebarList extends React.Component {
       .replace(/\//g, '_')
       .replace(/-/, '_')
       .replace(/\s/g, '_')
-
+      .replace(/\./, '\\.')
   }
 
   moveToAnchor(destination) {
@@ -79,7 +79,6 @@ export default class SidebarList extends React.Component {
   sidebarAnchorClicked(tag, op) {
     // this order is crucial to get the correct id
     let id = op.getIn(["operation", "__originalOperationId"]) || op.getIn(["operation", "operationId"]) || opId(op.get("operation"), op.get("path"), op.get('method')) || op.get("id")
-    // id = this.buildSidebarURL(id)
     this.setState({
       activeTags: [...this.state.activeTags, tag],
       activeId: id
@@ -87,8 +86,10 @@ export default class SidebarList extends React.Component {
     this.props.layoutActions.show(["operations-tag", tag], true)
     this.props.layoutActions.show(["operations", tag, id], true)
     let anchorPath = `operations-${tag}-${id}`
-    // this is needed because escaping is inconsistant
-    let anchor = document.querySelector(`#${anchorPath}`) || document.querySelector(`#operations-${this.buildSidebarURL(tag)}-${this.buildSidebarURL(id)}`)
+    let encodedPath = `operations-${this.buildSidebarURL(tag)}-${this.buildSidebarURL(id)}`
+    // this is needed because escaping is inconsistent
+    let anchor = document.getElementById(anchorPath) || document.getElementById(encodedPath)
+
     if (anchor) {
       this.moveToAnchor(anchor)
     }


### PR DESCRIPTION
swagger ui escapes "." in operations and tags to "\." for the css id
for example 
operation: "pet.cat", tag: "add pet" -> id: `#operations-pet\.cat-addAPet `

So I added one more regex to account for this. The tricky thing is previously we used querySelector which does not like `\`
Instead I am using getElementById, which means no need to prepend '#', but we still have to escape the \, so the regex is 

`.replace(/\./, '\\.')`

this now works:
![Screen Shot 2020-09-12 at 8 42 21 PM](https://user-images.githubusercontent.com/15886900/93009668-90879600-f538-11ea-90d5-0155d5885a82.png)
