### PR TITLE
fix(components): overwrite content-type component to add aria label

### DIFF
--- a/src/components/ContentType.js
+++ b/src/components/ContentType.js
@@ -1,0 +1,43 @@
+import React from "react"
+
+/**
+ * stripped down version of https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/content-type.jsx
+ * we needed to get the changes from https://github.com/swagger-api/swagger-ui/pull/7133
+ * as well a default aria label
+ */
+export default class ContentType extends React.Component {
+
+  componentDidMount() {
+    // Needed to populate the form, initially
+    if (this.props.contentTypes) {
+      this.props.onChange(this.props.contentTypes[0])
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!nextProps.contentTypes || !nextProps.contentTypes.length) {
+      return
+    }
+
+    if (!nextProps.contentTypes.includes(nextProps.value)) {
+      nextProps.onChange(nextProps.contentTypes[0])
+    }
+  }
+
+  onChangeWrapper = e => this.props.onChange(e.target.value)
+
+  render() {
+    let { ariaControls, ariaLabel = 'Content type', className, contentTypes, controlId, value } = this.props
+
+
+    return (
+      <div className={"content-type-wrapper " + (className || "")}>
+        <select aria-controls={ariaControls} aria-label={ariaLabel} className="content-type" id={controlId} onChange={this.onChangeWrapper} value={value || ""} >
+          {contentTypes.map((val) => {
+            return <option key={val} value={val}>{val}</option>
+          })}
+        </select>
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import AugmentingResponses from './components/AugmentingResponses'
 import AugmentingOperation from './components/AugmentingOperation.js'
 import Sidebar from './components/Sidebar'
 import SidebarList from './components/SidebarList'
+import ContentType from './components/ContentType'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -14,7 +15,8 @@ const SwaggerUIKongTheme = (system) => {
       curl: () => null,
       KongLayout: KongLayout,
       Sidebar: Sidebar,
-      SidebarList: SidebarList
+      SidebarList: SidebarList,
+      contentType: ContentType
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {


### PR DESCRIPTION
## Description
So this is not a perfect solution, discussed via huddle™


Pics below

Before
![Screen Shot 2021-10-27 at 8 34 37 AM](https://user-images.githubusercontent.com/2126677/139102674-43c802f1-49c0-4d98-8d93-68655c131b69.png)

---

After
![Screen Shot 2021-10-27 at 8 32 22 AM](https://user-images.githubusercontent.com/2126677/139102695-d8058153-1711-43eb-9660-26616d7808e5.png)
