### PR TITLE
fix(callbacks) fix error during callback render [TDX-1542]

### DIFF
--- a/src/components/AugmentingResponses.js
+++ b/src/components/AugmentingResponses.js
@@ -55,6 +55,14 @@ export default class AugmentingResponses extends React.Component {
       method,
       getConfigs
     } = this.props
+
+    const specPathSegments = this.props.specPath.toArray()
+    const isCallback = specPathSegments && specPathSegments.length && specPathSegments[3] === 'callbacks'
+
+    if (isCallback) {
+      return null
+    }
+
     const spec = specSelectors.specJson().toJS()
     const selectedServer = system.oas3Selectors.selectedServer()
     const scheme = specSelectors.operationScheme() || 'http'

--- a/src/components/AugmentingResponses.js
+++ b/src/components/AugmentingResponses.js
@@ -149,25 +149,25 @@ export default class AugmentingResponses extends React.Component {
       languages = config.theme.languages
     } else {
       languages = [
-      {
-        prismLanguage: 'bash',
-        target: 'shell',
-        client: 'curl'
-      },
-      {
-        prismLanguage: 'javascript',
-        target: 'javascript',
-        client: 'xhr'
-      },
-      {
-        prismLanguage: 'python',
-        target: 'python'
-      },{
-        prismLanguage: 'ruby',
-        target: 'ruby'
-      }
-    ]
-  }
+        {
+          prismLanguage: 'bash',
+          target: 'shell',
+          client: 'curl'
+        },
+        {
+          prismLanguage: 'javascript',
+          target: 'javascript',
+          client: 'xhr'
+        },
+        {
+          prismLanguage: 'python',
+          target: 'python'
+        },{
+          prismLanguage: 'ruby',
+          target: 'ruby'
+        }
+      ]
+    }
 
     return (
       <div className={'code-snippet'}>

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -99,7 +99,6 @@ export default class SidebarList extends React.Component {
     let encodedPath = `operations-${this.buildSidebarURL(tag)}-${this.buildSidebarURL(id)}`
     // this is needed because escaping is inconsistent
     let anchor = document.getElementById(anchorPath) || document.getElementById(encodedPath)
-    console.log({ anchor })
 
     if (anchor) {
       this.moveToAnchor(anchor)

--- a/src/styles.css
+++ b/src/styles.css
@@ -890,6 +890,33 @@
   background-color: var(--white);
 }
 
+.swagger-ui .callbacks-container h2 {
+  font-size: 20px;
+  margin: 10px 0 0 0;
+}
+
+.swagger-ui .callbacks-container .opblock {
+  margin: 0;
+}
+
+.swagger-ui .callbacks-container .opblock-summary * {
+  font-size: 12px
+}
+
+.swagger-ui .callbacks-container .opblock-summary {
+  padding-top: 4px;
+  padding-bottom: 8px;
+}
+
+.swagger-ui .opblock-body .callbacks-container.opblock-description-wrapper {
+  box-shadow: 0 0 50px 10px rgba(0,0,0,0.04);
+  padding: 20px;
+}
+
+.swagger-ui .callbacks-container .opblock-body {
+  display: block;
+}
+
 @media (min-width: 1000px) {
   /* we ie does not support implicet grids so we have to work around
       it also does not support grid-gaps so we use a extra col instead */


### PR DESCRIPTION
Callback requests were being passed to `swagger2har` along with regular spec requests, but callbacks are not supported by the way that swagger2har looks up the request in the swagger object. This bypasses the swagger2har and code snippets steps for callbacks, so their documentation can render without crashing.

Demo
![Screen Shot 2021-10-28 at 6 22 56 PM](https://user-images.githubusercontent.com/8764246/139344515-f5125dbc-8ee0-4984-87d6-8e72be0c376c.png)

![Screen Shot 2021-10-28 at 6 26 01 PM](https://user-images.githubusercontent.com/8764246/139344624-d435bb9f-b932-455f-b3b2-a866fe8ec2ed.png)