### PR TITLE
chore: add dev command to include source map and output a .debug.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/bundle.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack"
+    "build": "webpack",
+    "dev": "DEBUG=true webpack"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const hash = require('child_process')
 module.exports = {
   entry: './src/index.js',
   watch: true,
+  devtool: process.env.DEBUG ? 'eval-source-map' : undefined,
   module: {
     rules: [
       {
@@ -42,11 +43,14 @@ module.exports = {
   output: {
     path: __dirname + '/../kong-portal-templates/workspaces/default/themes/base/assets/js',
     publicPath: '/',
-    filename: `swagger-ui-kong-theme-${hash}.min.js`,
+    filename: `swagger-ui-kong-theme-${hash}.${process.env.DEBUG ? 'debug' : 'min'}.js`,
     library: 'SwaggerUIKongTheme',
     libraryTarget: 'umd'
   },
   devServer: {
     contentBase: './dist'
-  }
+  },
+  optimization: process.env.DEBUG ? {
+    minimize: false
+  } : undefined
 }


### PR DESCRIPTION
This adds an `npm run dev` command, which will set the `DEBUG` environment variable, which is picked up by the `webpack.config.js` to include a source map, skip output minimization, and change the output filename to end in `.debug.js` rather than `.min.js`.