### PR TITLE
style: fix some colors for a11y contrast issues 

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1013,7 +1013,7 @@
 }
 
 .swagger-ui .code-snippet .overlay .close{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(0, 0, 0, 1);
   cursor: pointer;
   position: absolute;
   top: 25%;
@@ -1023,7 +1023,7 @@
 }
 
 .swagger-ui .code-snippet .overlay .close:hover{
-  color:rgba(0, 0, 0, 1);
+  color:rgba(0, 0, 0, 0.5);
 }
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -647,7 +647,7 @@
   font-size: 13px;
   font-family: sans-serif;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.45)
+  color: var(--black-400);
 }
 
 .swagger-ui .parameters .parameters-col_name .prop-format{
@@ -660,7 +660,7 @@
   font-family: sans-serif;
   font-style: normal;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.45)
+  color: var(--black-400);
 }
 
 .swagger-ui .parameters .parameter__deprecated {


### PR DESCRIPTION
- I changed the color for parameters type to be a bit darker
- Also reversed the logic for the close due to contrast issues - so now it's black without hovering, and then lightens up when hovered.