### PR TITLE
fix(a11y) heading level and contrast [TDX-1618]

### DIFF
--- a/src/components/AugmentingResponses.js
+++ b/src/components/AugmentingResponses.js
@@ -174,7 +174,7 @@ export default class AugmentingResponses extends React.Component {
          { !mutatedRequest &&
           <div className={`overlay ${this.state.overlay}`}>
             <span aria-label="close" role="button" className='close' onKeyUp={(e) => handleCloseKeyup(e.key)} onClick={() => this.handleClose()}>x</span>
-            <h3>Use 'Try it Out' to see completed code snippet</h3>
+            <p>Use 'Try it Out' to see completed code snippet</p>
           </div>
           }
           <CodeSnippetWidget har={har} snippets={languages}/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -560,7 +560,7 @@
   padding: 4px 0px;
 }
 
-.swagger-ui .opblock .opblock-section-header h4 {
+.swagger-ui .opblock .opblock-section-header h1 {
   font-size: 16px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1105,7 +1105,7 @@
 }
 
 
-.swagger-ui .code-snippet .overlay h3{
+.swagger-ui .code-snippet .overlay p {
   text-align: center;
   margin: 30px;
   font-size: 1.17em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -968,7 +968,7 @@
   background-color: var(--white);
 }
 
-.swagger-ui .callbacks-container h2 {
+.swagger-ui .callbacks-container h1 {
   font-size: 20px;
   margin: 10px 0 0 0;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -558,6 +558,7 @@
   right: 20px;
   word-break: normal;
   padding: 4px 0px;
+  background-color: var(--black-400);
 }
 
 .swagger-ui .opblock .opblock-section-header h1 {
@@ -1022,6 +1023,15 @@
   -ms-grid-column: 1;
   padding: 16px 0 20px 13em;
   height: 71px;
+}
+
+.swagger-ui .try-out .btn.cancel {
+  color: var(--red-600);
+  border-color: var(--red-600);
+}
+
+.swagger-ui .btn.execute {
+  background-color: var(--blue-500);
 }
 
 .swagger-ui .opblock-body .execute-wrapper {


### PR DESCRIPTION
This resolves styles for:
- heading levels must only increase by one [TDX-1618]
- try it now buttons color contrast [TDX-1651]

[TDX-1618]: https://konghq.atlassian.net/browse/TDX-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TDX-1651]: https://konghq.atlassian.net/browse/TDX-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ