### PR TITLE
fix: overwrite examples select component for aria label change (TDX-1891)

### DIFF
--- a/src/components/ExamplesSelect.js
+++ b/src/components/ExamplesSelect.js
@@ -85,7 +85,7 @@
            ) : null
          }
          <select
-           aria-label="Select for example response"
+           aria-label="Select a example response"
            onChange={this._onDomSelect}
            value={
              isModifiedValueAvailable && isValueModified

--- a/src/components/ExamplesSelect.js
+++ b/src/components/ExamplesSelect.js
@@ -1,4 +1,5 @@
 /**
+ * Original file: https://github.com/swagger-api/swagger-ui/blob/3.x/src/core/components/examples-select.jsx
  * @prettier
  */
 

--- a/src/components/ExamplesSelect.js
+++ b/src/components/ExamplesSelect.js
@@ -1,0 +1,116 @@
+/**
+ * @prettier
+ */
+
+ import React from "react"
+ 
+ export default class ExamplesSelect extends React.PureComponent {
+    _onSelect = (key, { isSyntheticChange = false } = {}) => {
+     if (typeof this.props.onSelect === "function") {
+       this.props.onSelect(key, {
+         isSyntheticChange,
+       })
+     }
+   }
+ 
+   _onDomSelect = e => {
+     if (typeof this.props.onSelect === "function") {
+       const element = e.target.selectedOptions[0]
+       const key = element.getAttribute("value")
+ 
+       this._onSelect(key, {
+         isSyntheticChange: false,
+       })
+     }
+   }
+ 
+   getCurrentExample = () => {
+     const { examples, currentExampleKey } = this.props
+ 
+     const currentExamplePerProps = examples.get(currentExampleKey)
+ 
+     const firstExamplesKey = examples.keySeq().first()
+     const firstExample = examples.get(firstExamplesKey)
+ 
+     return currentExamplePerProps || firstExample || Map({})
+   }
+ 
+   componentDidMount() {
+     // this is the not-so-great part of ExamplesSelect... here we're
+     // artificially kicking off an onSelect event in order to set a default
+     // value in state. the consumer has the option to avoid this by checking
+     // `isSyntheticEvent`, but we should really be doing this in a selector.
+     // TODO: clean this up
+     // FIXME: should this only trigger if `currentExamplesKey` is nullish?
+     const { onSelect, examples } = this.props
+ 
+     if (typeof onSelect === "function") {
+       const firstExample = examples.first()
+       const firstExampleKey = examples.keyOf(firstExample)
+ 
+       this._onSelect(firstExampleKey, {
+         isSyntheticChange: true,
+       })
+     }
+   }
+ 
+   componentWillReceiveProps(nextProps) {
+     const { currentExampleKey, examples } = nextProps
+     if (examples !== this.props.examples && !examples.has(currentExampleKey)) {
+       // examples have changed from under us, and the currentExampleKey is no longer
+       // valid.
+       const firstExample = examples.first()
+       const firstExampleKey = examples.keyOf(firstExample)
+ 
+       this._onSelect(firstExampleKey, {
+         isSyntheticChange: true,
+       })
+     }
+   }
+ 
+   render() {
+     const {
+       examples,
+       currentExampleKey,
+       isValueModified,
+       isModifiedValueAvailable,
+       showLabels,
+     } = this.props
+ 
+     return (
+       <div className="examples-select">
+         {
+           showLabels ? (
+             <span className="examples-select__section-label">Examples: </span>
+           ) : null
+         }
+         <select
+           aria-label="Select for example response"
+           onChange={this._onDomSelect}
+           value={
+             isModifiedValueAvailable && isValueModified
+               ? "__MODIFIED__VALUE__"
+               : (currentExampleKey || "")
+           }
+         >
+           {isModifiedValueAvailable ? (
+             <option value="__MODIFIED__VALUE__">[Modified value]</option>
+           ) : null}
+           {examples
+             .map((example, exampleName) => {
+               return (
+                 <option
+                   key={exampleName} // for React
+                   value={exampleName} // for matching to select's `value`
+                 >
+                   {example.get("summary") || exampleName}
+                 </option>
+               )
+             })
+             .valueSeq()}
+         </select>
+       </div>
+     )
+   }
+ }
+ 

--- a/src/components/ExamplesSelect.js
+++ b/src/components/ExamplesSelect.js
@@ -85,7 +85,7 @@
            ) : null
          }
          <select
-           aria-label="Select a example response"
+           aria-label="Select an example response"
            onChange={this._onDomSelect}
            value={
              isModifiedValueAvailable && isValueModified

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import AugmentingOperation from './components/AugmentingOperation.js'
 import Sidebar from './components/Sidebar'
 import SidebarList from './components/SidebarList'
 import ContentType from './components/ContentType'
+import ExamplesSelect from './components/ExamplesSelect'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -15,7 +16,8 @@ const SwaggerUIKongTheme = (system) => {
       KongLayout: KongLayout,
       Sidebar: Sidebar,
       SidebarList: SidebarList,
-      contentType: ContentType
+      contentType: ContentType,
+      ExamplesSelect: ExamplesSelect
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {


### PR DESCRIPTION
Took a similar approach to @codelemur 's changes for the content type change