### PR TITLE
fix: update models + modelcollapse components to be tabbable

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^2.0.2",
     "curl-to-har": "^1.0.1",
+    "immutable": "^3.x.x",
     "react-apiembed": "^0.1.4",
     "swagger2har": "git+https://github.com/Kong/swagger2har.git#8409def1fd72311f44b1d34e669af76226cb4f59"
   },

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -1,0 +1,74 @@
+import React, { Component } from "react"
+
+export default class ModelCollapse extends Component {
+  constructor(props, context) {
+    super(props, context)
+
+    let { expanded, collapsedContent } = this.props
+
+    this.state = {
+      expanded: expanded,
+      collapsedContent: collapsedContent || ModelCollapse.defaultProps.collapsedContent
+    }
+  }
+
+  componentDidMount() {
+    const { hideSelfOnExpand, expanded, modelName } = this.props
+    if (hideSelfOnExpand && expanded) {
+      // We just mounted pre-expanded, and we won't be going back..
+      // So let's give our parent an `onToggle` call..
+      // Since otherwise it will never be called.
+      this.props.onToggle(modelName, expanded)
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.expanded !== nextProps.expanded) {
+      this.setState({ expanded: nextProps.expanded })
+    }
+  }
+
+  handleKeyDownToggle = (event) => {
+    if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
+      this.toggleCollapsed()
+    }
+  }
+
+  toggleCollapsed = () => {
+    if (this.props.onToggle) {
+      this.props.onToggle(this.props.modelName, !this.state.expanded)
+    }
+
+    this.setState({
+      expanded: !this.state.expanded
+    })
+  }
+
+  render() {
+    const { title, classes } = this.props
+
+
+    return (
+      <div className={classes || ""}>
+        {this.state.expanded && this.props.hideSelfOnExpand ? this.props.children : (
+          <div>
+            { title && 
+              <div 
+                role="button"
+                aria-pressed={this.state.expanded}
+                onClick={this.toggleCollapsed}
+                onKeyDown={(e) => this.handleKeyDownToggle(e)}
+                tabIndex={0}
+                style={{ "cursor": "pointer", "display": "inline-block" }}
+              >{title}</div>
+            }
+            <span onClick={ this.toggleCollapsed } style={{ "cursor": "pointer" }}>
+              <span className={ "model-toggle" + ( this.state.expanded ? "" : " collapsed" ) }></span>
+            </span>
+            { this.state.expanded ? this.props.children :this.state.collapsedContent }
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -1,3 +1,8 @@
+/**
+ * Original file: https://github.com/swagger-api/swagger-ui/blob/3.x/src/core/components/model-collapse.jsx
+ * @prettier
+ */
+
 import React, { Component } from "react"
 
 export default class ModelCollapse extends Component {
@@ -52,8 +57,8 @@ export default class ModelCollapse extends Component {
       <div className={classes || ""}>
         {this.state.expanded && this.props.hideSelfOnExpand ? this.props.children : (
           <div>
-            { title && 
-              <div 
+            {title &&
+              <div
                 role="button"
                 aria-pressed={this.state.expanded}
                 onClick={this.toggleCollapsed}
@@ -62,10 +67,10 @@ export default class ModelCollapse extends Component {
                 style={{ "cursor": "pointer", "display": "inline-block" }}
               >{title}</div>
             }
-            <span onClick={ this.toggleCollapsed } style={{ "cursor": "pointer" }}>
-              <span className={ "model-toggle" + ( this.state.expanded ? "" : " collapsed" ) }></span>
+            <span onClick={this.toggleCollapsed} style={{ "cursor": "pointer" }}>
+              <span className={"model-toggle" + (this.state.expanded ? "" : " collapsed")}></span>
             </span>
-            { this.state.expanded ? this.props.children :this.state.collapsedContent }
+            {this.state.expanded ? this.props.children : this.state.collapsedContent}
           </div>
         )}
       </div>

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -1,5 +1,5 @@
 /**
- * Original file: https://github.com/swagger-api/swagger-ui/blob/3.x/src/core/components/model-collapse.jsx
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/model-collapse.jsx
  * @prettier
  */
 

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -1,5 +1,5 @@
 /**
- * Original file: https://github.com/swagger-api/swagger-ui/blob/3.x/src/core/components/models.jsx
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/models.jsx
  * @prettier
  */
 

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -1,3 +1,8 @@
+/**
+ * Original file: https://github.com/swagger-api/swagger-ui/blob/3.x/src/core/components/models.jsx
+ * @prettier
+ */
+
 import React, { Component } from "react"
 import Im, { Map } from "immutable"
 
@@ -14,7 +19,7 @@ export default class Models extends Component {
   handleToggle = (name, isExpanded) => {
     const { layoutActions } = this.props
     layoutActions.show(["models", name], isExpanded)
-    if(isExpanded) {
+    if (isExpanded) {
       this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
     }
   }
@@ -26,7 +31,7 @@ export default class Models extends Component {
     }
   }
 
-  render(){
+  render() {
     let { specSelectors, getComponent, layoutSelectors, layoutActions, getConfigs } = this.props
     let definitions = specSelectors.definitions()
     let { docExpansion, defaultModelsExpandDepth } = getConfigs()
@@ -41,8 +46,8 @@ export default class Models extends Component {
     const ModelCollapse = getComponent("ModelCollapse")
     const JumpToPath = getComponent("JumpToPath")
 
-    return <section className={ showModels ? "models is-open" : "models"}>
-      <div 
+    return <section className={showModels ? "models is-open" : "models"}>
+      <div
         role="button"
         aria-pressed={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
@@ -50,7 +55,7 @@ export default class Models extends Component {
         tabIndex={0}
       >
         <h1>
-          <span>{isOAS3 ? "Schemas" : "Models" }</span>
+          <span>{isOAS3 ? "Schemas" : "Models"}</span>
           <svg width="20" height="20">
             <use xlinkHref={showModels ? "#large-arrow-down" : "#large-arrow"} />
           </svg>
@@ -58,7 +63,7 @@ export default class Models extends Component {
       </div>
       <Collapse isOpened={showModels}>
         {
-          definitions.entrySeq().map(([name])=>{
+          definitions.entrySeq().map(([name]) => {
 
             const fullPath = [...specPathBase, name]
 
@@ -69,10 +74,10 @@ export default class Models extends Component {
             const rawSchema = Map.isMap(rawSchemaValue) ? rawSchemaValue : Im.Map()
 
             const displayName = schema.get("title") || rawSchema.get("title") || name
-            const isShown = layoutSelectors.isShown( ["models", name], false )
+            const isShown = layoutSelectors.isShown(["models", name], false)
             const isExpanded = defaultModelsExpandDepth > 0 && isShown
 
-            if( isShown && (schema.size === 0 && rawSchema.size > 0) ) {
+            if (isShown && (schema.size === 0 && rawSchema.size > 0)) {
               // Firing an action in a container render is not great,
               // but it works for now.
               this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
@@ -80,16 +85,16 @@ export default class Models extends Component {
 
             const specPath = Im.List([...specPathBase, name])
 
-            const content = <ModelWrapper name={ name }
-              expandDepth={ defaultModelsExpandDepth }
-              schema={ schema || Im.Map() }
+            const content = <ModelWrapper name={name}
+              expandDepth={defaultModelsExpandDepth}
+              schema={schema || Im.Map()}
               displayName={displayName}
               specPath={specPath}
-              getComponent={ getComponent }
-              specSelectors={ specSelectors }
-              getConfigs = {getConfigs}
-              layoutSelectors = {layoutSelectors}
-              layoutActions = {layoutActions}/>
+              getComponent={getComponent}
+              specSelectors={specSelectors}
+              getConfigs={getConfigs}
+              layoutSelectors={layoutSelectors}
+              layoutActions={layoutActions} />
 
             const title = <span className="model-box">
               <span className="model model-title">
@@ -97,7 +102,7 @@ export default class Models extends Component {
               </span>
             </span>
 
-            return <div id={ `model-${name}` } className="model-container" key={ `models-section-${name}` }>
+            return <div id={`model-${name}`} className="model-container" key={`models-section-${name}`}>
               <span className="models-jump-to-path"><JumpToPath specPath={specPath} /></span>
               <ModelCollapse
                 classes="model-box"
@@ -108,8 +113,8 @@ export default class Models extends Component {
                 modelName={name}
                 hideSelfOnExpand={true}
                 expanded={isExpanded}
-                >{content}</ModelCollapse>
-              </div>
+              >{content}</ModelCollapse>
+            </div>
           }).toArray()
         }
       </Collapse>

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -1,0 +1,118 @@
+import React, { Component } from "react"
+import Im, { Map } from "immutable"
+
+export default class Models extends Component {
+  getSchemaBasePath = () => {
+    const isOAS3 = this.props.specSelectors.isOAS3()
+    return isOAS3 ? ["components", "schemas"] : ["definitions"]
+  }
+
+  getCollapsedContent = () => {
+    return " "
+  }
+
+  handleToggle = (name, isExpanded) => {
+    const { layoutActions } = this.props
+    layoutActions.show(["models", name], isExpanded)
+    if(isExpanded) {
+      this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
+    }
+  }
+
+  handleKeypress = (event, showModels) => {
+    const { layoutActions } = this.props
+    if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
+      layoutActions.show("models", !showModels)
+    }
+  }
+
+  render(){
+    let { specSelectors, getComponent, layoutSelectors, layoutActions, getConfigs } = this.props
+    let definitions = specSelectors.definitions()
+    let { docExpansion, defaultModelsExpandDepth } = getConfigs()
+    if (!definitions.size || defaultModelsExpandDepth < 0) return null
+
+    let showModels = layoutSelectors.isShown("models", defaultModelsExpandDepth > 0 && docExpansion !== "none")
+    const specPathBase = this.getSchemaBasePath()
+    const isOAS3 = specSelectors.isOAS3()
+
+    const ModelWrapper = getComponent("ModelWrapper")
+    const Collapse = getComponent("Collapse")
+    const ModelCollapse = getComponent("ModelCollapse")
+    const JumpToPath = getComponent("JumpToPath")
+
+    return <section className={ showModels ? "models is-open" : "models"}>
+      <div 
+        role="button"
+        aria-pressed={showModels}
+        onClick={() => layoutActions.show("models", !showModels)}
+        onKeyDown={(e) => this.handleKeypress(e, showModels)}
+        tabIndex={0}
+      >
+        <h1>
+          <span>{isOAS3 ? "Schemas" : "Models" }</span>
+          <svg width="20" height="20">
+            <use xlinkHref={showModels ? "#large-arrow-down" : "#large-arrow"} />
+          </svg>
+        </h1>
+      </div>
+      <Collapse isOpened={showModels}>
+        {
+          definitions.entrySeq().map(([name])=>{
+
+            const fullPath = [...specPathBase, name]
+
+            const schemaValue = specSelectors.specResolvedSubtree(fullPath)
+            const rawSchemaValue = specSelectors.specJson().getIn(fullPath)
+
+            const schema = Map.isMap(schemaValue) ? schemaValue : Im.Map()
+            const rawSchema = Map.isMap(rawSchemaValue) ? rawSchemaValue : Im.Map()
+
+            const displayName = schema.get("title") || rawSchema.get("title") || name
+            const isShown = layoutSelectors.isShown( ["models", name], false )
+            const isExpanded = defaultModelsExpandDepth > 0 && isShown
+
+            if( isShown && (schema.size === 0 && rawSchema.size > 0) ) {
+              // Firing an action in a container render is not great,
+              // but it works for now.
+              this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
+            }
+
+            const specPath = Im.List([...specPathBase, name])
+
+            const content = <ModelWrapper name={ name }
+              expandDepth={ defaultModelsExpandDepth }
+              schema={ schema || Im.Map() }
+              displayName={displayName}
+              specPath={specPath}
+              getComponent={ getComponent }
+              specSelectors={ specSelectors }
+              getConfigs = {getConfigs}
+              layoutSelectors = {layoutSelectors}
+              layoutActions = {layoutActions}/>
+
+            const title = <span className="model-box">
+              <span className="model model-title">
+                {displayName}
+              </span>
+            </span>
+
+            return <div id={ `model-${name}` } className="model-container" key={ `models-section-${name}` }>
+              <span className="models-jump-to-path"><JumpToPath specPath={specPath} /></span>
+              <ModelCollapse
+                classes="model-box"
+                collapsedContent={this.getCollapsedContent(name)}
+                onToggle={this.handleToggle}
+                title={title}
+                displayName={displayName}
+                modelName={name}
+                hideSelfOnExpand={true}
+                expanded={isExpanded}
+                >{content}</ModelCollapse>
+              </div>
+          }).toArray()
+        }
+      </Collapse>
+    </section>
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import Sidebar from './components/Sidebar'
 import SidebarList from './components/SidebarList'
 import ContentType from './components/ContentType'
 import ExamplesSelect from './components/ExamplesSelect'
+import Models from './components/Models'
+import ModelCollapse from './components/ModelCollapse'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -17,7 +19,9 @@ const SwaggerUIKongTheme = (system) => {
       Sidebar: Sidebar,
       SidebarList: SidebarList,
       contentType: ContentType,
-      ExamplesSelect: ExamplesSelect
+      ExamplesSelect: ExamplesSelect,
+      Models: Models,
+      ModelCollapse: ModelCollapse
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,6 +2646,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+immutable@^3.x.x:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"


### PR DESCRIPTION
Copied the components from `swagger-ui` and cleaned them up a bit to be more readable, as well as add in the tabbable portions. Tested with voiceover.