### PR TITLE
fix: add aria-label to filter by tag input (TDX-1888)

### DIFF
--- a/src/containers/Filter.js
+++ b/src/containers/Filter.js
@@ -1,0 +1,35 @@
+import React from "react"
+
+export default class FilterContainer extends React.Component {
+  onFilterChange = (e) => {
+    const {target: {value}} = e
+    this.props.layoutActions.updateFilter(value)
+  }
+
+  render () {
+    const {specSelectors, layoutSelectors, getComponent} = this.props
+    const Col = getComponent("Col")
+
+    const isLoading = specSelectors.loadingStatus() === "loading"
+    const isFailed = specSelectors.loadingStatus() === "failed"
+    const filter = layoutSelectors.currentFilter()
+
+    const inputStyle = {}
+    if (isFailed) inputStyle.color = "red"
+    if (isLoading) inputStyle.color = "#aaa"
+
+    return (
+      <div>
+        {filter === null || filter === false ? null :
+          <div className="filter-container">
+            <Col className="filter wrapper" mobile={12}>
+              <input className="operation-filter-input" aria-label="Input for filtering by tag" placeholder="Filter by tag" type="text"
+                     onChange={this.onFilterChange} value={filter === true || filter === "true" ? "" : filter}
+                     disabled={isLoading} style={inputStyle}/>
+            </Col>
+          </div>
+        }
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import ContentType from './components/ContentType'
 import ExamplesSelect from './components/ExamplesSelect'
 import Models from './components/Models'
 import ModelCollapse from './components/ModelCollapse'
+import FilterContainer from './containers/Filter'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -21,7 +22,8 @@ const SwaggerUIKongTheme = (system) => {
       contentType: ContentType,
       ExamplesSelect: ExamplesSelect,
       Models: Models,
-      ModelCollapse: ModelCollapse
+      ModelCollapse: ModelCollapse,
+      FilterContainer: FilterContainer
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {


### PR DESCRIPTION
This PR adds an `aria-label` attribute to the `FilterContainer` component.