### PR TITLE
fix: make entire operation-tag collapsible, rename some functions (TDX-1887)

### DIFF
--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -33,7 +33,7 @@ export default class ModelCollapse extends Component {
     }
   }
 
-  handleKeyDownToggle = (event) => {
+  handleKeypress = (event) => {
     if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
       this.toggleCollapsed()
     }
@@ -62,7 +62,7 @@ export default class ModelCollapse extends Component {
                 role="button"
                 aria-pressed={this.state.expanded}
                 onClick={this.toggleCollapsed}
-                onKeyDown={(e) => this.handleKeyDownToggle(e)}
+                onKeyUp={(e) => this.handleKeypress(e)}
                 tabIndex={0}
                 style={{ "cursor": "pointer", "display": "inline-block" }}
               >{title}</div>

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -51,7 +51,7 @@ export default class Models extends Component {
         role="button"
         aria-pressed={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
-        onKeyDown={(e) => this.handleKeypress(e, showModels)}
+        onKeyUp={(e) => this.handleKeypress(e, showModels)}
         tabIndex={0}
       >
         <h1>

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -42,7 +42,7 @@ export default class OperationTag extends React.Component {
     let showTag = layoutSelectors.isShown(isShownKey, docExpansion === "full" || docExpansion === "list")
 
     return (
-      <div
+      <section
         className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
         aria-expanded={showTag}
         >
@@ -98,7 +98,7 @@ export default class OperationTag extends React.Component {
         <Collapse isOpened={showTag}>
           {children}
         </Collapse>
-      </div>
+      </section>
     )
   }
 }

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -1,0 +1,104 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/operation-tag.jsx
+ * @prettier
+ */
+
+import React from "react"
+import { createDeepLinkPath, escapeDeepLinkPath, sanitizeUrl } from '../helpers/helpers'
+
+export default class OperationTag extends React.Component {
+  handleKeypress = (event, isShownKey, showTag) => {
+    const { layoutActions } = this.props
+
+    if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
+      layoutActions.show(isShownKey, showTag)
+    }
+  }
+
+  render() {
+    const {
+      tagObj,
+      tag,
+      children,
+
+      layoutSelectors,
+      layoutActions,
+      getConfigs,
+      getComponent,
+    } = this.props
+
+    let { docExpansion } = getConfigs()
+
+    const Collapse = getComponent("Collapse")
+    const Markdown = getComponent("Markdown")
+    const DeepLink = getComponent("DeepLink")
+    const Link = getComponent("Link")
+
+    let tagDescription = tagObj.getIn(["tagDetails", "description"], null)
+    let tagExternalDocsDescription = tagObj.getIn(["tagDetails", "externalDocs", "description"])
+    let tagExternalDocsUrl = tagObj.getIn(["tagDetails", "externalDocs", "url"])
+
+    let isShownKey = ["operations-tag", tag]
+    let showTag = layoutSelectors.isShown(isShownKey, docExpansion === "full" || docExpansion === "list")
+
+    return (
+      <div
+        className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
+        aria-expanded={showTag}
+        >
+        <h1
+          className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
+          id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
+          onClick={() => layoutActions.show(isShownKey, !showTag)}
+          onKeyUp={(e) => this.handleKeypress(e, isShownKey, !showTag)}
+          data-tag={tag}
+          data-is-open={showTag}
+          tabIndex={0}
+          >
+          <DeepLink
+            tabIndex={-1}
+            enabled={false} // Set to false, as we don't seem to be doing anything when deeplinking.
+            isShown={showTag}
+            path={createDeepLinkPath(tag)}
+            text={tag} />
+          { !tagDescription ? <small></small> :
+            <small>
+                <Markdown source={tagDescription} />
+              </small>
+            }
+
+            <div>
+              { !tagExternalDocsDescription ? null :
+                <small>
+                    { tagExternalDocsDescription }
+                      { tagExternalDocsUrl ? ": " : null }
+                      { tagExternalDocsUrl ?
+                        <Link
+                            href={sanitizeUrl(tagExternalDocsUrl)}
+                            onClick={(e) => e.stopPropagation()}
+                            target="_blank"
+                            >{tagExternalDocsUrl}</Link> : null
+                          }
+                  </small>
+                }
+            </div>
+
+            <button
+              className="expand-operation"
+              title={showTag ? "Collapse operation": "Expand operation"}
+              onClick={() => layoutActions.show(isShownKey, !showTag)}
+              tabIndex={-1}
+              >
+
+              <svg className="arrow" width="20" height="20">
+                <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
+              </svg>
+            </button>
+        </h1>
+        <Collapse isOpened={showTag}>
+          {children}
+        </Collapse>
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import ContentType from './components/ContentType'
 import ExamplesSelect from './components/ExamplesSelect'
 import Models from './components/Models'
 import ModelCollapse from './components/ModelCollapse'
+import OperationTag from './components/OperationTag'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -21,7 +22,8 @@ const SwaggerUIKongTheme = (system) => {
       contentType: ContentType,
       ExamplesSelect: ExamplesSelect,
       Models: Models,
-      ModelCollapse: ModelCollapse
+      ModelCollapse: ModelCollapse,
+      OperationTag: OperationTag
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {


### PR DESCRIPTION
This PR fixes the issue with the `OperationTag`  not focusing on the right elements. It now focuses on the entire header element, and toggles on keypress / click. Also renames some functions in other files.

@Mierenga I added the `aria-expanded` attribute on the containing `div` instead, as I think that makes more sense semantically (since the div is being collapsed / expanded, not the header).