### PR TITLE
fix: make responses section tabbable and readable (TDX-1890)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "@braintree/sanitize-url": "^2.0.2",
     "curl-to-har": "^1.0.1",
     "immutable": "^3.x.x",
+    "js-file-download": "^0.4.1",
     "react-apiembed": "^0.1.4",
+    "react-debounce-input": "^3.2.0",
     "swagger2har": "git+https://github.com/Kong/swagger2har.git#8409def1fd72311f44b1d34e669af76226cb4f59"
   },
   "devDependencies": {
@@ -50,7 +52,6 @@
     "css-loader": "^2.1.1",
     "file-loader": "^4.0.0",
     "react": "15.6.2",
-    "react-debounce-input": "^3.2.0",
     "style-loader": "^0.23.1",
     "uglifyjs-webpack-plugin": "^2.1.3",
     "webpack": "^4.32.2",

--- a/src/components/HighlightCode.js
+++ b/src/components/HighlightCode.js
@@ -1,0 +1,62 @@
+import React, { Component } from "react"
+import { highlight } from "../helpers/helpers"
+import saveAs from "js-file-download"
+
+export default class HighlightCode extends Component {
+  componentDidMount() {
+    highlight(this.el)
+  }
+
+  componentDidUpdate() {
+    highlight(this.el)
+  }
+
+  initializeComponent = (c) => {
+    this.el = c
+  }
+
+  downloadText = () => {
+    saveAs(this.props.value, this.props.fileName || "response.txt")
+  }
+
+  preventYScrollingBeyondElement = (e) => {
+    const target = e.target
+
+    var deltaY = e.nativeEvent.deltaY
+    var contentHeight = target.scrollHeight
+    var visibleHeight = target.offsetHeight
+    var scrollTop = target.scrollTop
+
+    const scrollOffset = visibleHeight + scrollTop
+
+    const isElementScrollable = contentHeight > visibleHeight
+    const isScrollingPastTop = scrollTop === 0 && deltaY < 0
+    const isScrollingPastBottom = scrollOffset >= contentHeight && deltaY > 0
+
+    if (isElementScrollable && (isScrollingPastTop || isScrollingPastBottom)) {
+      e.preventDefault()
+    }
+  }
+
+  render () {
+    let { value, className, downloadable } = this.props
+    className = className || ""
+
+    return (
+      <div className="highlight-code" tabIndex={0}>
+        { !downloadable ? null :
+          <div className="download-contents" onClick={this.downloadText}>
+            Download
+          </div>
+        }
+        <pre
+          ref={this.initializeComponent}
+          onWheel={this.preventYScrollingBeyondElement}
+          className={className + " microlight"}
+          tabIndex="0">
+          {value}
+        </pre>
+      </div>
+    )
+  }
+}

--- a/src/components/ModelExample.js
+++ b/src/components/ModelExample.js
@@ -1,0 +1,112 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/model-example.jsx
+ * @prettier
+ */
+
+import React from "react"
+
+export default class ModelExample extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+    let { getConfigs, isExecute } = this.props
+    let { defaultModelRendering } = getConfigs()
+
+    let activeTab = defaultModelRendering
+
+    if (defaultModelRendering !== "example" && defaultModelRendering !== "model") {
+      activeTab = "example"
+    }
+
+    if(isExecute) {
+      activeTab = "example"
+    }
+
+    this.state = {
+      activeTab: activeTab
+    }
+  }
+
+  activeTab =( e ) => {
+    let { target : { dataset : { name } } } = e
+
+    this.setState({
+      activeTab: name
+    })
+  }
+
+  handleKeypress = (event) => {
+    if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
+      this.activeTab(event)
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      nextProps.isExecute &&
+      !this.props.isExecute &&
+      this.props.example
+    ) {
+      this.setState({ activeTab: "example" })
+    }
+  }
+
+  render() {
+    let { getComponent, specSelectors, schema, example, isExecute, getConfigs, specPath } = this.props
+    let { defaultModelExpandDepth } = getConfigs()
+    const ModelWrapper = getComponent("ModelWrapper")
+    const HighlightCode = getComponent("highlightCode")
+
+    let isOAS3 = specSelectors.isOAS3()
+
+    return <div className="model-example">
+      <ul className="tab">
+        <li className={ "tabitem" + ( this.state.activeTab === "example" ? " active" : "") }>
+          <a
+            role="button"
+            tabIndex={0}
+            aria-label={isExecute ? "Anchor tag to open edit value" : "Anchor tag to display example value"}
+            onKeyUp={(e) => this.handleKeypress(e)}
+            className="tablinks"
+            data-name="example"
+            onClick={ this.activeTab }
+          >
+            {isExecute ? "Edit Value" : "Example Value"}
+          </a>
+        </li>
+        { schema ? <li className={ "tabitem" + ( this.state.activeTab === "model" ? " active" : "") }>
+          <a
+            role="button"
+            tabIndex={0}
+            aria-label={isOAS3 ? "Anchor tag to show schema" : "Anchor tag to show model" }
+            onKeyUp={(e) => this.handleKeypress(e)}
+            className={ "tablinks" + ( isExecute ? " inactive" : "" )}
+            data-name="model"
+            onClick={ this.activeTab }
+          >
+            {isOAS3 ? "Schema" : "Model" }
+          </a>
+        </li> : null }
+      </ul>
+      <div>
+        {
+          this.state.activeTab === "example" ? (
+            example ? example : (
+              <HighlightCode value="(no example available)" />
+            )
+          ) : null
+        }
+        {
+          this.state.activeTab === "model" && (
+            <ModelWrapper schema={ schema }
+              getComponent={ getComponent }
+              getConfigs={ getConfigs }
+              specSelectors={ specSelectors }
+              expandDepth={ defaultModelExpandDepth }
+              specPath={specPath} />
+          )
+        }
+      </div>
+    </div>
+  }
+
+}

--- a/src/components/ModelWrapper.js
+++ b/src/components/ModelWrapper.js
@@ -1,0 +1,34 @@
+import React, { Component, } from "react"
+
+export default class ModelWrapper extends Component {
+  onToggle = (name,isShown) => {
+    // If this prop is present, we'll have deepLinking for it
+    if(this.props.layoutActions) {
+      this.props.layoutActions.show(["models", name],isShown)
+    }
+  }
+
+  render(){
+    let { getComponent, getConfigs } = this.props
+    const Model = getComponent("Model")
+
+    let expanded
+    if (this.props.layoutSelectors) {
+      // If this is prop is present, we'll have deepLinking for it
+      expanded = this.props.layoutSelectors.isShown(["models",this.props.name])
+    }
+
+    return (
+      <div className="model-box" tabIndex={0}>
+        <Model
+          { ...this.props }
+          getConfigs={ getConfigs }
+          expanded={expanded}
+          depth={ 1 }
+          onToggle={ this.onToggle }
+          expandDepth={ this.props.expandDepth || 0 }
+        />
+      </div>
+    )
+  }
+}

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -48,3 +48,164 @@ export function sanitizeUrl(url) {
 
   return braintreeSanitizeUrl(url)
 }
+
+
+/**
+ * Adapted from http://github.com/asvd/microlight
+ * @copyright 2016 asvd <heliosframework@gmail.com>
+ */
+ export function highlight (el) {
+  const MAX_LENGTH = 5000
+  var
+    _document = document,
+    appendChild = "appendChild",
+    test = "test"
+
+  if (!el) return ""
+  if (el.textContent.length > MAX_LENGTH) { return el.textContent }
+
+  var reset = function(el) {
+    var text = el.textContent,
+      pos = 0, // current position
+      next1 = text[0], // next character
+      chr = 1, // current character
+      prev1, // previous character
+      prev2, // the one before the previous
+      token = // current token content
+        el.innerHTML = "", // (and cleaning the node)
+
+    // current token type:
+    //  0: anything else (whitespaces / newlines)
+    //  1: operator or brace
+    //  2: closing braces (after which '/' is division not regex)
+    //  3: (key)word
+    //  4: regex
+    //  5: string starting with "
+    //  6: string starting with '
+    //  7: xml comment  <!-- -->
+    //  8: multiline comment /* */
+    //  9: single-line comment starting with two slashes //
+    // 10: single-line comment starting with hash #
+      tokenType = 0,
+
+    // kept to determine between regex and division
+      lastTokenType,
+    // flag determining if token is multi-character
+      multichar,
+      node
+
+    // running through characters and highlighting
+    while (prev2 = prev1,
+      // escaping if needed (with except for comments)
+      // previous character will not be therefore
+      // recognized as a token finalize condition
+      prev1 = tokenType < 7 && prev1 == "\\" ? 1 : chr
+      ) {
+      chr = next1
+      next1=text[++pos]
+      multichar = token.length > 1
+
+      // checking if current token should be finalized
+      if (!chr || // end of content
+          // types 9-10 (single-line comments) end with a
+          // newline
+        (tokenType > 8 && chr == "\n") ||
+        [ // finalize conditions for other token types
+          // 0: whitespaces
+          /\S/[test](chr), // merged together
+          // 1: operators
+          1, // consist of a single character
+          // 2: braces
+          1, // consist of a single character
+          // 3: (key)word
+          !/[$\w]/[test](chr),
+          // 4: regex
+          (prev1 == "/" || prev1 == "\n") && multichar,
+          // 5: string with "
+          prev1 == "\"" && multichar,
+          // 6: string with '
+          prev1 == "'" && multichar,
+          // 7: xml comment
+          text[pos-4]+prev2+prev1 == "-->",
+          // 8: multiline comment
+          prev2+prev1 == "*/"
+        ][tokenType]
+      ) {
+        // appending the token to the result
+        if (token) {
+          // remapping token type into style
+          // (some types are highlighted similarly)
+          el[appendChild](
+            node = _document.createElement("span")
+          ).setAttribute("style", [
+            // 0: not formatted
+            "color: #555; font-weight: bold;",
+            // 1: keywords
+            "",
+            // 2: punctuation
+            "",
+            // 3: strings and regexps
+            "color: #555;",
+            // 4: comments
+            ""
+          ][
+            // not formatted
+            !tokenType ? 0 :
+              // punctuation
+              tokenType < 3 ? 2 :
+                // comments
+                tokenType > 6 ? 4 :
+                  // regex and strings
+                  tokenType > 3 ? 3 :
+                    // otherwise tokenType == 3, (key)word
+                    // (1 if regexp matches, 0 otherwise)
+                    + /^(a(bstract|lias|nd|rguments|rray|s(m|sert)?|uto)|b(ase|egin|ool(ean)?|reak|yte)|c(ase|atch|har|hecked|lass|lone|ompl|onst|ontinue)|de(bugger|cimal|clare|f(ault|er)?|init|l(egate|ete)?)|do|double|e(cho|ls?if|lse(if)?|nd|nsure|num|vent|x(cept|ec|p(licit|ort)|te(nds|nsion|rn)))|f(allthrough|alse|inal(ly)?|ixed|loat|or(each)?|riend|rom|unc(tion)?)|global|goto|guard|i(f|mp(lements|licit|ort)|n(it|clude(_once)?|line|out|stanceof|t(erface|ernal)?)?|s)|l(ambda|et|ock|ong)|m(icrolight|odule|utable)|NaN|n(amespace|ative|ext|ew|il|ot|ull)|o(bject|perator|r|ut|verride)|p(ackage|arams|rivate|rotected|rotocol|ublic)|r(aise|e(adonly|do|f|gister|peat|quire(_once)?|scue|strict|try|turn))|s(byte|ealed|elf|hort|igned|izeof|tatic|tring|truct|ubscript|uper|ynchronized|witch)|t(emplate|hen|his|hrows?|ransient|rue|ry|ype(alias|def|id|name|of))|u(n(checked|def(ined)?|ion|less|signed|til)|se|sing)|v(ar|irtual|oid|olatile)|w(char_t|hen|here|hile|ith)|xor|yield)$/[test](token)
+            ])
+
+          node[appendChild](_document.createTextNode(token))
+        }
+
+        // saving the previous token type
+        // (skipping whitespaces and comments)
+        lastTokenType =
+          (tokenType && tokenType < 7) ?
+            tokenType : lastTokenType
+
+        // initializing a new token
+        token = ""
+
+        // determining the new token type (going up the
+        // list until matching a token type start
+        // condition)
+        tokenType = 11
+        while (![
+          1, //  0: whitespace
+                               //  1: operator or braces
+          /[\/{}[(\-+*=<>:;|\\.,?!&@~]/[test](chr), // eslint-disable-line no-useless-escape
+          /[\])]/[test](chr), //  2: closing brace
+          /[$\w]/[test](chr), //  3: (key)word
+          chr == "/" && //  4: regex
+            // previous token was an
+            // opening brace or an
+            // operator (otherwise
+            // division, not a regex)
+          (lastTokenType < 2) &&
+            // workaround for xml
+            // closing tags
+          prev1 != "<",
+          chr == "\"", //  5: string with "
+          chr == "'", //  6: string with '
+                               //  7: xml comment
+          chr+next1+text[pos+1]+text[pos+2] == "<!--",
+          chr+next1 == "/*", //  8: multiline comment
+          chr+next1 == "//", //  9: single-line comment
+          chr == "#" // 10: hash-style comment
+        ][--tokenType]);
+      }
+
+      token += chr
+    }
+  }
+
+  return reset(el)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ import Models from './components/Models'
 import ModelCollapse from './components/ModelCollapse'
 import FilterContainer from './containers/Filter'
 import Operations from './components/Operations'
+import ModelExample from './components/ModelExample'
+import ModelWrapper from './components/ModelWrapper'
+import HighlightCode from './components/HighlightCode'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -25,7 +28,10 @@ const SwaggerUIKongTheme = (system) => {
       Models: Models,
       ModelCollapse: ModelCollapse,
       FilterContainer: FilterContainer,
-      operations: Operations
+      operations: Operations,
+      modelExample: ModelExample,
+      ModelWrapper: ModelWrapper,
+      highlightCode: HighlightCode
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,6 +2891,11 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+js-file-download@^0.4.1:
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
+  integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION

https://user-images.githubusercontent.com/40131297/162484341-cb792796-7f45-4991-92b0-9b018445d55c.mov

This PR makes the examples + schema / model buton tabbable as well as making the voiceover read the content of each item. Also included `aria-label`s on both of the anchor tags so it's more accessible.