### PR TITLE
fix: refactor sidebar list to remove roles (TDX-1894)

### DIFF
--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -82,7 +82,7 @@ export default class SidebarList extends React.Component {
   }
 
   sidebarAnchorKeyup(key, tag, op) {
-    if (key === 'Enter') {
+    if (key === 'Enter' || key === ' ') {
       this.sidebarAnchorSelected(tag, op)
     }
   }
@@ -165,23 +165,24 @@ export default class SidebarList extends React.Component {
               >
                 {tag}
               </span>
-              <ul className="submenu-items" role="menu" hidden={!this.isTagActive(tag)}>
+              <ul className="submenu-items" hidden={!this.isTagActive(tag)}>
                 {sidebarItem.get("operations").map(op =>
-                  <li
-                    role="menuitem"
-                    className={"method" + this.getActiveClass(op)}
-                    tabIndex={this.isTagActive(tag) ? 0 : -1}
-                    onKeyUp={(e) => this.sidebarAnchorKeyup(e.key, tag, op)}
-                    onClick={() => this.sidebarAnchorClicked(tag, op)}
-
-                  >
-                    <span className={"method-tag method-tag-"+op.get("method")}>{op.get("method")}</span>
-                    <a
-                      className={"method-" + op.get("method")}
-                      role="none"
+                  <li className={"method" + this.getActiveClass(op)}>
+                    <div 
+                      role="button"
+                      className="method-button-wrapper"
+                      tabIndex={this.isTagActive(tag) ? 0 : -1}
+                      onKeyUp={(e) => this.sidebarAnchorKeyup(e.key, tag, op)}
+                      onClick={() => this.sidebarAnchorClicked(tag, op)}
                     >
-                      {this.summaryOrPath(op)}
-                    </a>
+                      <span className={"method-tag method-tag-"+op.get("method")}>{op.get("method")}</span>
+                      <a
+                        className={"method-" + op.get("method")}
+                        role="none"
+                      >
+                        {this.summaryOrPath(op)}
+                      </a>
+                    </div>
                   </li>
                 )}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -213,7 +213,7 @@
 .sidebar-list ul li .submenu-items a:active {
   border-style: solid;
 }
-.sidebar-list ul li .submenu-items li.active > a {
+.sidebar-list ul li .submenu-items li.active > div.method-button-wrapper > a {
   font-weight: 500;
 }
 
@@ -246,6 +246,11 @@
 }
 .sidebar-list ul li.method {
   display: flex;
+  align-items: center;
+}
+.sidebar-list ul li.method div.method-button-wrapper {
+  display: flex;
+  width: 100%;
   align-items: center;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -213,7 +213,7 @@
 .sidebar-list ul li .submenu-items a:active {
   border-style: solid;
 }
-.sidebar-list ul li .submenu-items li.active > div.method-button-wrapper > a {
+.sidebar-list ul li .submenu-items li.active a {
   font-weight: 500;
 }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/40131297/162846820-2fa8ea30-6b1b-40b2-ac24-eeb7533836db.mov


Previously, focus would get stuck on the sidebar menu when using voice control to expand one of the menu items. This was caused due to the `role="menuitem"`, so those were removed. `role="button"` isn't allowed to be used on an `<li>` tag, so I wrapped the contents in a div and applied the listeners + role on the div. Result is in the above label - functionally and visually looks the same, but works with voice control