### PR TITLE
fix: add aria descriptions to try it out button

### DIFF
--- a/src/components/TryItOutButton.js
+++ b/src/components/TryItOutButton.js
@@ -1,0 +1,16 @@
+import React from "react"
+
+export default class TryItOutButton extends React.Component {
+  render() {
+    const { onTryoutClick, onCancelClick, enabled } = this.props
+
+    return (
+      <div className="try-out">
+        {
+          enabled ? <button aria-description="Cancel sending an example request" className="btn try-out__btn cancel" onClick={ onCancelClick }>Cancel</button>
+                  : <button aria-description="Try sending an example request" className="btn try-out__btn" onClick={ onTryoutClick }>Try it out </button>
+        }
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import Operations from './components/Operations'
 import ModelExample from './components/ModelExample'
 import ModelWrapper from './components/ModelWrapper'
 import HighlightCode from './components/HighlightCode'
+import TryItOutButton from './components/TryItOutButton'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -33,7 +34,8 @@ const SwaggerUIKongTheme = (system) => {
       operations: Operations,
       modelExample: ModelExample,
       ModelWrapper: ModelWrapper,
-      highlightCode: HighlightCode
+      highlightCode: HighlightCode,
+      TryItOutButton: TryItOutButton
     },
     wrapComponents: {
       responses: (Original, system) => (props) => {


### PR DESCRIPTION
The issue was that the buttons weren't descriptive enough - this adds a description that voice over will now read out when you are focused on the button.