### PR TITLE
chore: minor fixes to a11y changes

### DIFF
--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -44,7 +44,6 @@ export default class OperationTag extends React.Component {
     return (
       <div
         className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
-        aria-expanded={showTag}
         >
         <h1
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
@@ -87,6 +86,7 @@ export default class OperationTag extends React.Component {
               className="expand-operation"
               title={showTag ? "Collapse operation": "Expand operation"}
               onClick={() => layoutActions.show(isShownKey, !showTag)}
+              aria-expanded={showTag}
               tabIndex={-1}
               >
 

--- a/src/components/TryItOutButton.js
+++ b/src/components/TryItOutButton.js
@@ -7,8 +7,8 @@ export default class TryItOutButton extends React.Component {
     return (
       <div className="try-out">
         {
-          enabled ? <button aria-description="Cancel sending an example request" className="btn try-out__btn cancel" onClick={ onCancelClick }>Cancel</button>
-                  : <button aria-description="Try sending an example request" className="btn try-out__btn" onClick={ onTryoutClick }>Try it out </button>
+          enabled ? <button aria-label="Cancel sending an example request" className="btn try-out__btn cancel" onClick={ onCancelClick }>Cancel</button>
+                  : <button aria-label="Try sending an example request" className="btn try-out__btn" onClick={ onTryoutClick }>Try it out </button>
         }
       </div>
     )


### PR DESCRIPTION
Changing location of `aria-expanded` and usage of `aria-label` instead of `aria-description`