### PR TITLE
feat(try-it-out): add more details to inline error messages for param… [TDX-2351]

### DIFF
--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -108,7 +108,7 @@ export default class ParameterRow extends Component {
       .get("content", Map())
       .keySeq()
       .first()
-    
+
     // getSampleSchema could return null
     const generatedSampleValue = schema ? getSampleSchema(schema.toJS(), parameterMediaType, {
       includeWriteOnly: true
@@ -150,7 +150,7 @@ export default class ParameterRow extends Component {
         this.onChangeWrapper(initialValue)
       } else if(
         schema && schema.get("type") === "object"
-        && generatedSampleValue 
+        && generatedSampleValue
         && !paramWithMeta.get("examples")
       ) {
         // Object parameters get special treatment.. if the user doesn't set any
@@ -178,8 +178,8 @@ export default class ParameterRow extends Component {
   }
 
   // Kong change - format error
-  getParameterRowErrorProps = (errors) => {
-    return errors?.toJS ? errors.toJS() : []
+  getParameterRowErrorProps = (errors, param) => {
+    return errors?.toJS ? errors.toJS().map(err => `Invalid value for property ${param.name} in ${param.in} section: ${err}`) : []
   }
 
   render() {
@@ -336,7 +336,7 @@ export default class ParameterRow extends Component {
 
           {/* Kong change -  Display error message in case of errors */}
           { bodyParam ? null
-            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} /> }
+            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"), paramWithMeta.toJS())} /> }
 
           {
             bodyParam && schema ? <ModelExample getComponent={ getComponent }

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -179,7 +179,14 @@ export default class ParameterRow extends Component {
 
   // Kong change - format error
   getParameterRowErrorProps = (errors, param) => {
-    return errors?.toJS ? errors.toJS().map(err => `Invalid value for property ${param.name} in ${param.in} section: ${err}`) : []
+    if (errors && errors.toJS().length >=1) {
+      return {
+        errors: errors.toJS(),
+        param: param
+      }
+    } else {
+      return []
+    }
   }
 
   render() {

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -40,7 +40,8 @@ export class ParameterRowError extends Component {
         tabIndex='-1'
         ref={this.initializeComponent}
       >
-        {errors.join('. ')}
+        <span className='error-parameter-name'>Invalid value for property {errors.param.name} in {errors.param.in} section:</span>
+        <span className='errors-details'>{errors.errors.join('. ')}</span>
       </div>
     )
   }


### PR DESCRIPTION
…eters

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/2126677/186279054-c5cda986-8100-4a97-9a00-fec61ebb5cd3.png">

^^ shows query param display

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/2126677/186279083-2f8a623f-dbf3-49b1-bb64-be9e26c9f4a4.png">

^^ shows path error display

