### PR TITLE
chore: add class to view spec button + styles (TDX-2350)

### DIFF
--- a/src/components/AugmentingInfo.js
+++ b/src/components/AugmentingInfo.js
@@ -88,7 +88,11 @@ class ViewSpec extends React.Component {
 
   render(){
     return (
-      <button onClick={() => this.handleViewSpecClick()}>
+      <button 
+        id="viewRawSpecButton"
+        className="btn"
+        onClick={() => this.handleViewSpecClick()}
+      >
         <EyeSVG></EyeSVG> View Raw
       </button>
     )

--- a/src/styles.css
+++ b/src/styles.css
@@ -414,6 +414,12 @@
   box-shadow: none;
 }
 
+.swagger-ui .btn:focus {
+  outline: solid;
+  outline-color: var(--black-500);
+  transition: outline 1ms linear;
+}
+
 .swagger-ui .btn.authorize {
   color: rgb(0, 149, 255);
   border: 1px rgb(0, 149, 255) solid;


### PR DESCRIPTION
This PR adds a class to the view spec button so that targeting is simpler when closing the spec modal. In addition, some styles are added in order to improve accessibility. Previously, the outline was removed from buttons so you would not be able to tell if you were focused on them or not.

<img width="193" alt="Screen Shot 2022-08-24 at 10 12 44 AM" src="https://user-images.githubusercontent.com/40131297/186469281-ba1b0599-dfb1-4a4b-aaa9-eefae87b9964.png">
 