### PR TITLE
feat(try-it-out): add more details to inline error messages

### DIFF
--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -322,6 +322,11 @@ export default class ParameterRow extends Component {
             ) : null
           }
 
+          {/* Kong change -  Display error message in case of errors */}
+          { bodyParam ? null
+            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
+          }
+
           { bodyParam ? null
             : <JsonSchemaForm fn={fn}
                               getComponent={getComponent}
@@ -332,11 +337,6 @@ export default class ParameterRow extends Component {
                               onChange={ this.onChangeWrapper }
                               errors={ paramWithMeta.get("errors") }
                               schema={ schema }/>
-          }
-
-          {/* Kong change -  Display error message in case of errors */}
-          { bodyParam ? null
-            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
           }
 
           {

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -322,11 +322,6 @@ export default class ParameterRow extends Component {
             ) : null
           }
 
-          {/* Kong change -  Display error message in case of errors */}
-          { bodyParam ? null
-            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
-          }
-
           { bodyParam ? null
             : <JsonSchemaForm fn={fn}
                               getComponent={getComponent}
@@ -337,6 +332,11 @@ export default class ParameterRow extends Component {
                               onChange={ this.onChangeWrapper }
                               errors={ paramWithMeta.get("errors") }
                               schema={ schema }/>
+          }
+
+          {/* Kong change -  Display error message in case of errors */}
+          { bodyParam ? null
+            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
           }
 
           {

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -108,7 +108,7 @@ export default class ParameterRow extends Component {
       .get("content", Map())
       .keySeq()
       .first()
-    
+
     // getSampleSchema could return null
     const generatedSampleValue = schema ? getSampleSchema(schema.toJS(), parameterMediaType, {
       includeWriteOnly: true
@@ -150,7 +150,7 @@ export default class ParameterRow extends Component {
         this.onChangeWrapper(initialValue)
       } else if(
         schema && schema.get("type") === "object"
-        && generatedSampleValue 
+        && generatedSampleValue
         && !paramWithMeta.get("examples")
       ) {
         // Object parameters get special treatment.. if the user doesn't set any
@@ -336,7 +336,8 @@ export default class ParameterRow extends Component {
 
           {/* Kong change -  Display error message in case of errors */}
           { bodyParam ? null
-            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} /> }
+            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
+          }
 
           {
             bodyParam && schema ? <ModelExample getComponent={ getComponent }

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -32,7 +32,8 @@ export class ParameterRowError extends Component {
   }
 
   render() {
-    const { errors } = this.props
+    const { errors, param } = this.props
+
 
     return (
       <div
@@ -40,7 +41,8 @@ export class ParameterRowError extends Component {
         tabIndex='-1'
         ref={this.initializeComponent}
       >
-        {errors.join('. ')}
+        {errors.length ? <span className='error-parameter-name'>Invalid value for property {param.name} in {param.in} section:&nbsp;</span> : null }
+        <span className='errors-details'>{errors.join('. ')}</span>
       </div>
     )
   }

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -38,7 +38,7 @@ export class ParameterRowError extends Component {
     return (
       <div
         className='parameter-row-error'
-        tabIndex='-1'
+        tabIndex={errors.length ? -1 : 1}
         ref={this.initializeComponent}
       >
         {errors.length ? <span className='error-parameter-name'>Invalid value for property {param.name} in {param.in} section:&nbsp;</span> : null }

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -38,7 +38,7 @@ export class ParameterRowError extends Component {
     return (
       <div
         className='parameter-row-error'
-        tabIndex={errors.length ? -1 : 1}
+        tabIndex='-1'
         ref={this.initializeComponent}
       >
         {errors.length ? <span className='error-parameter-name'>Invalid value for property {param.name} in {param.in} section:&nbsp;</span> : null }

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -41,8 +41,9 @@ export class ParameterRowError extends Component {
         tabIndex='-1'
         ref={this.initializeComponent}
       >
-        {errors.length ? <span className='error-parameter-name'>Invalid value for property {param.name} in {param.in} section:&nbsp;</span> : null }
-        <span className='errors-details'>{errors.join('. ')}</span>
+        {errors.length ? <p className='error-parameter-name' role="alert">
+          Invalid value for property {param.name} in {param.in} section:&nbsp; <span className='errors-details'>{errors.join('. ')}</span>
+        </p> : null }
       </div>
     )
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1192,6 +1192,10 @@
   height: unset;
 }
 
+.swagger-ui .parameters .error-parameter-name {
+  margin-bottom: 0;
+}
+
 .swagger-ui .parameters .parameters-col_description .parameter-row-error  {
   font-size: 12px;
   color: var(--red-600);


### PR DESCRIPTION
Round 2 without console errors:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/2126677/186518274-c5134f52-1f20-4335-94b4-a34807f7d996.png">
<img width="796" alt="image" src="https://user-images.githubusercontent.com/2126677/186518351-4fcf6233-ceec-43b2-8e06-5fbed49c1496.png">

[Loom demo](https://www.loom.com/share/0c45191208bb4958b7b302e17a4d9d04)

Would love to see one with multiple errors but not sure how that'd play out.