### PR TITLE
refactor: use a div instead of link (TDX-2382) (TDX-2383)

### DIFF
--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { createDeepLinkPath, escapeDeepLinkPath, sanitizeUrl } from '../helpers/helpers'
+import { escapeDeepLinkPath, sanitizeUrl } from '../helpers/helpers'
 
 export default class OperationTag extends React.Component {
   handleKeypress = (event, isShownKey, showTag) => {
@@ -31,7 +31,6 @@ export default class OperationTag extends React.Component {
 
     const Collapse = getComponent("Collapse")
     const Markdown = getComponent("Markdown")
-    const DeepLink = getComponent("DeepLink")
     const Link = getComponent("Link")
 
     let tagDescription = tagObj.getIn(["tagDetails", "description"], null)
@@ -54,18 +53,14 @@ export default class OperationTag extends React.Component {
           data-is-open={showTag}
           tabIndex={0}
           >
-          <DeepLink
-            tabIndex={-1}
-            showArrow={false}
-            enabled={false} // Set to false, as we don't seem to be doing anything when deeplinking.
-            isShown={showTag}
-            path={createDeepLinkPath(tag)}
-            text={tag} />
+          <div className="nostyle">
+            <span>{tag}</span>
+          </div>
           { !tagDescription ? <small></small> :
             <small>
-                <Markdown source={tagDescription} />
-              </small>
-            }
+              <Markdown source={tagDescription} />
+            </small>
+          }
 
             <div>
               { !tagExternalDocsDescription ? null :
@@ -89,8 +84,7 @@ export default class OperationTag extends React.Component {
               onClick={() => layoutActions.show(isShownKey, !showTag)}
               aria-expanded={showTag}
               tabIndex={-1}
-              >
-
+            >
               <svg className="arrow" width="20" height="20">
                 <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
               </svg>

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -43,7 +43,7 @@ export default class OperationTag extends React.Component {
     return (
       <div
         className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
-        >
+      >
         <h1
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
           id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
@@ -52,43 +52,43 @@ export default class OperationTag extends React.Component {
           data-tag={tag}
           data-is-open={showTag}
           tabIndex={0}
-          >
-          <div className="nostyle">
+        >
+          <p className="nostyle text-wrapper">
             <span>{tag}</span>
-          </div>
+          </p>
           { !tagDescription ? <small></small> :
             <small>
               <Markdown source={tagDescription} />
             </small>
           }
 
-            <div>
-              { !tagExternalDocsDescription ? null :
-                <small>
-                    { tagExternalDocsDescription }
-                      { tagExternalDocsUrl ? ": " : null }
-                      { tagExternalDocsUrl ?
-                        <Link
-                            href={sanitizeUrl(tagExternalDocsUrl)}
-                            onClick={(e) => e.stopPropagation()}
-                            target="_blank"
-                            >{tagExternalDocsUrl}</Link> : null
-                          }
-                  </small>
-                }
-            </div>
+          <p className="text-wrapper">
+            { !tagExternalDocsDescription ? null :
+              <small>
+                  { tagExternalDocsDescription }
+                    { tagExternalDocsUrl ? ": " : null }
+                    { tagExternalDocsUrl ?
+                      <Link
+                          href={sanitizeUrl(tagExternalDocsUrl)}
+                          onClick={(e) => e.stopPropagation()}
+                          target="_blank"
+                          >{tagExternalDocsUrl}</Link> : null
+                        }
+                </small>
+              }
+          </p>
 
-            <button
-              className="expand-operation"
-              title={showTag ? "Collapse operation": "Expand operation"}
-              onClick={() => layoutActions.show(isShownKey, !showTag)}
-              aria-expanded={showTag}
-              tabIndex={-1}
-            >
-              <svg className="arrow" width="20" height="20">
-                <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
-              </svg>
-            </button>
+          <button
+            className="expand-operation"
+            title={showTag ? "Collapse operation": "Expand operation"}
+            onClick={() => layoutActions.show(isShownKey, !showTag)}
+            aria-expanded={showTag}
+            tabIndex={-1}
+          >
+            <svg className="arrow" width="20" height="20">
+              <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
+            </svg>
+          </button>
         </h1>
         <Collapse isOpened={showTag}>
           {children}

--- a/src/styles.css
+++ b/src/styles.css
@@ -592,6 +592,10 @@
   padding: 12px 0;
 }
 
+.swagger-ui .opblock-tag .text-wrapper {
+  margin-bottom: 0;
+}
+
 .swagger-ui .opblock-tag .nostyle span {
   color: var(--black-70);
   font-size: 24px;


### PR DESCRIPTION
The accessibility around this title was unclear. Since there's already a button functionality wrapped around this container, the link was replaced with a `div` - meaning that it should not need any `aria` properties to describe it, nor should it need a title attribute. Visually - they should look the exact same

Before
<img width="1539" alt="Screen Shot 2022-09-15 at 9 16 24 AM" src="https://user-images.githubusercontent.com/40131297/190484070-48076436-ffba-4dee-b68a-79957bcee833.png">
After
<img width="1546" alt="Screen Shot 2022-09-15 at 9 16 45 AM" src="https://user-images.githubusercontent.com/40131297/190484072-e2c2ba6a-1001-4571-a450-fee32d6d7e65.png">
