### PR TITLE
fix(a11y): removes overusage of h1 tags

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -6,13 +6,8 @@
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 
-const NoMargin = ({ children, id }) => {
-  if (id) {
-    return <div role="region" id={id} style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
-  } else {
-    return <div role="region" style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
-  }
-
+const NoMargin = ({ children, id, labelledBy }) => {
+  return <div id={id} aria-labelledby={labelledBy} role="region" style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
 }
 
 NoMargin.propTypes = {
@@ -26,7 +21,8 @@ export default class Collapse extends Component {
     isOpened: PropTypes.bool,
     children: PropTypes.node.isRequired,
     animated: PropTypes.bool,
-    id: PropTypes.string
+    id: PropTypes.string,
+    labelledBy: PropTypes.string
   }
 
   static defaultProps = {
@@ -40,21 +36,21 @@ export default class Collapse extends Component {
     }
 
     return (
-      <NoMargin id={this.props.id}>
+      <NoMargin id={this.props.id} labelledBy={this.props.labelledBy}>
         {this.props.children}
       </NoMargin>
     )
   }
 
   render() {
-    let { animated, isOpened, children, id } = this.props
+    let { animated, isOpened, children, id, labelledBy } = this.props
 
     if (!animated)
       return this.renderNotAnimated()
 
     children = isOpened ? children : null
     return (
-      <NoMargin id={id}>
+      <NoMargin id={id} labelledBy={labelledBy}>
         {children}
       </NoMargin>
     )

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -1,0 +1,63 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/layout-utils.jsx Collapse class
+ * @prettier
+ */
+
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+const NoMargin = ({ children, id }) => {
+  if (id) {
+    return <div role="region" id={id} style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
+  } else {
+    return <div role="region" style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
+  }
+
+}
+
+NoMargin.propTypes = {
+  children: PropTypes.node,
+  id: PropTypes.string
+}
+
+export default class Collapse extends Component {
+
+  static propTypes = {
+    isOpened: PropTypes.bool,
+    children: PropTypes.node.isRequired,
+    animated: PropTypes.bool,
+    id: PropTypes.string
+  }
+
+  static defaultProps = {
+    isOpened: false,
+    animated: false
+  }
+
+  renderNotAnimated() {
+    if (!this.props.isOpened) {
+      return <noscript />
+    }
+
+    return (
+      <NoMargin id={this.props.id}>
+        {this.props.children}
+      </NoMargin>
+    )
+  }
+
+  render() {
+    let { animated, isOpened, children, id } = this.props
+
+    if (!animated)
+      return this.renderNotAnimated()
+
+    children = isOpened ? children : null
+    return (
+      <NoMargin id={id}>
+        {children}
+      </NoMargin>
+    )
+  }
+
+}

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -54,12 +54,13 @@ export default class Models extends Component {
         onKeyUp={(e) => this.handleKeypress(e, showModels)}
         tabIndex={0}
       >
-        <h1>
-          <span>{isOAS3 ? "Schemas" : "Models"}</span>
+        <div className="flex-wrapper">
+        <span>{isOAS3 ? "Schemas" : "Models"}</span>
           <svg width="20" height="20">
             <use xlinkHref={showModels ? "#large-arrow-down" : "#large-arrow"} />
           </svg>
-        </h1>
+        </div>
+
       </div>
       <Collapse isOpened={showModels}>
         {

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -47,12 +47,11 @@ export default class Models extends Component {
     const JumpToPath = getComponent("JumpToPath")
 
     return <section className={showModels ? "models is-open" : "models"}>
-      <div
-        role="button"
+      <button
+        className="btn"
+        type="button"
         aria-pressed={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
-        onKeyUp={(e) => this.handleKeypress(e, showModels)}
-        tabIndex={0}
       >
         <div className="flex-wrapper">
         <span>{isOAS3 ? "Schemas" : "Models"}</span>
@@ -61,7 +60,7 @@ export default class Models extends Component {
           </svg>
         </div>
 
-      </div>
+      </button>
       <Collapse isOpened={showModels}>
         {
           definitions.entrySeq().map(([name]) => {

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -45,7 +45,7 @@ export default class OperationTag extends React.Component {
         className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
         >
         <div
-          role={"rowheader"}
+          role="rowheader"
           aria-expanded={showTag}
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
           id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -58,21 +58,6 @@ export default class OperationTag extends React.Component {
             </small>
           }
 
-          <p className="text-wrapper">
-            { !tagExternalDocsDescription ? null :
-              <small>
-                  { tagExternalDocsDescription }
-                    { tagExternalDocsUrl ? ": " : null }
-                    { tagExternalDocsUrl ?
-                      <Link
-                          href={sanitizeUrl(tagExternalDocsUrl)}
-                          onClick={(e) => e.stopPropagation()}
-                          target="_blank"
-                          >{tagExternalDocsUrl}</Link> : null
-                        }
-                </small>
-              }
-          </p>
 
             <div
               className="arrow-wrapper expand-operation"
@@ -84,10 +69,27 @@ export default class OperationTag extends React.Component {
               </svg>
             </div>
         </button>
-        <Collapse id={opBlockSectionCollapseKeyId} isOpened={showTag}>
+        <Collapse labelledBy={opBlockSectionKeyId} id={opBlockSectionCollapseKeyId} isOpened={showTag}>
+          {buildExternalDocsLink(tagExternalDocsDescription, tagExternalDocsUrl, Link)}
           {children}
         </Collapse>
       </div>
     )
   }
 }
+function buildExternalDocsLink(tagExternalDocsDescription, tagExternalDocsUrl, Link) {
+  return <p className="text-wrapper">
+    {!tagExternalDocsDescription ? null :
+      <small>
+        {tagExternalDocsDescription}
+        {tagExternalDocsUrl ? ": " : null}
+        {tagExternalDocsUrl ?
+          <Link
+            href={sanitizeUrl(tagExternalDocsUrl)}
+            onClick={(e) => e.stopPropagation()}
+            target="_blank"
+          >{tagExternalDocsUrl}</Link> : null}
+      </small>}
+  </p>
+}
+

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -7,13 +7,6 @@ import React from "react"
 import { escapeDeepLinkPath, sanitizeUrl } from '../helpers/helpers'
 
 export default class OperationTag extends React.Component {
-  handleKeypress = (event, isShownKey, showTag) => {
-    const { layoutActions } = this.props
-
-    if (event.nativeEvent.code === "Enter" || event.nativeEvent.code === "Space") {
-      layoutActions.show(isShownKey, showTag)
-    }
-  }
 
   render() {
     const {
@@ -40,20 +33,21 @@ export default class OperationTag extends React.Component {
     let isShownKey = ["operations-tag", tag]
     let showTag = layoutSelectors.isShown(isShownKey, docExpansion === "full" || docExpansion === "list")
 
+    const opBlockSectionKeyId = isShownKey.map(v => escapeDeepLinkPath(v)).join("-")
+    const opBlockSectionCollapseKeyId = opBlockSectionKeyId+'-collapse'
     return (
       <div
-        className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
+        className={showTag ? "opblock-tag-section" : "opblock-tag-section"}
         >
-        <div
-          role="rowheader"
+        <button
+          type="button"
           aria-expanded={showTag}
-          className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
-          id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
+          className={'btn opblock-tag-btn ' + (!tagDescription ? "opblock-tag no-desc" : "opblock-tag") }
+          id={opBlockSectionKeyId}
+          aria-controls={opBlockSectionCollapseKeyId}
           onClick={() => layoutActions.show(isShownKey, !showTag)}
-          onKeyUp={(e) => this.handleKeypress(e, isShownKey, !showTag)}
           data-tag={tag}
           data-is-open={showTag}
-          tabIndex={0}
         >
           <p className="nostyle text-wrapper">
             <span>{tag}</span>
@@ -80,20 +74,17 @@ export default class OperationTag extends React.Component {
               }
           </p>
 
-            <button
-              className="expand-operation"
+            <div
+              className="arrow-wrapper expand-operation"
               title={showTag ? "Collapse operation": "Expand operation"}
-              onClick={() => layoutActions.show(isShownKey, !showTag)}
-              aria-expanded={showTag}
-              tabIndex={-1}
               >
 
               <svg className="arrow" width="20" height="20">
                 <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
               </svg>
-            </button>
-        </div>
-        <Collapse isOpened={showTag}>
+            </div>
+        </button>
+        <Collapse id={opBlockSectionCollapseKeyId} isOpened={showTag}>
           {children}
         </Collapse>
       </div>

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -43,8 +43,10 @@ export default class OperationTag extends React.Component {
     return (
       <div
         className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"}
-      >
-        <h1
+        >
+        <div
+          role={"rowheader"}
+          aria-expanded={showTag}
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
           id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
           onClick={() => layoutActions.show(isShownKey, !showTag)}
@@ -78,18 +80,19 @@ export default class OperationTag extends React.Component {
               }
           </p>
 
-          <button
-            className="expand-operation"
-            title={showTag ? "Collapse operation": "Expand operation"}
-            onClick={() => layoutActions.show(isShownKey, !showTag)}
-            aria-expanded={showTag}
-            tabIndex={-1}
-          >
-            <svg className="arrow" width="20" height="20">
-              <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
-            </svg>
-          </button>
-        </h1>
+            <button
+              className="expand-operation"
+              title={showTag ? "Collapse operation": "Expand operation"}
+              onClick={() => layoutActions.show(isShownKey, !showTag)}
+              aria-expanded={showTag}
+              tabIndex={-1}
+              >
+
+              <svg className="arrow" width="20" height="20">
+                <use href={showTag ? "#large-arrow-down" : "#large-arrow"} xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />
+              </svg>
+            </button>
+        </div>
         <Collapse isOpened={showTag}>
           {children}
         </Collapse>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import ParameterRow from './components/ParameterRow'
 import AuthorizationPopup from './components/auth/authorization-popup'
 import AuthorizeBtn from './components/auth/authorize-btn'
 import AuthorizeOperationBtn from './components/auth/authorize-operation-btn'
+import Collapse from './components/Collapse'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -65,6 +66,7 @@ const SwaggerUIKongTheme = (system) => {
     },
     components: {
       curl: () => null,
+      Collapse: Collapse,
       KongLayout: KongLayout,
       Sidebar: Sidebar,
       SidebarList: SidebarList,
@@ -82,7 +84,7 @@ const SwaggerUIKongTheme = (system) => {
       ModelWrapper: ModelWrapper,
       highlightCode: HighlightCode,
       TryItOutButton: TryItOutButton,
-      parameterRow: ParameterRow
+      parameterRow: ParameterRow,
     },
     wrapComponents: {
       authorizeBtn: (Original, system) => (props) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1212,6 +1212,26 @@
   color: var(--red-600);
 }
 
+
+.swagger-ui section.models .flex-wrapper {
+  display: flex;
+  font-size: 16px;
+  align-items: center;
+  margin: 0;
+  padding: 10px 20px 10px 10px;
+  cursor: pointer;
+  transition: all .2s;
+  font-family: sans-serif;
+  color: #606060;
+}
+
+.swagger-ui section.models .flex-wrapper :first-child {
+  flex: 1
+}
+.swagger-ui section.models .flex-wrapper svg {
+  transition: all .4s;
+}
+
 /**************************************************************************
  * From templates repo, not sure if needed, consildating all css in one spot before removing
  * swagger-ui container

--- a/src/styles.css
+++ b/src/styles.css
@@ -608,10 +608,28 @@
   font-size: 14px;
   color: var(--black-70);
   padding-left: 10px;
+  text-align: left;
 }
 
 .swagger-ui .opblock-tag small p {
   color: var(--black-70);
+}
+
+.swagger-ui .opblock-tag .arrow-wrapper {
+  padding: 0 30px;
+}
+
+.swagger-ui button.opblock-tag.opblock-tag-btn {
+  border-top: none;
+  height: auto;
+  border-left: none;
+  border-right: none;
+  display: flex;
+  overflow: hidden;
+  align-items: center;
+  box-shadow: none;
+  border-radius: 0;
+  border-bottom-width: 1px;
 }
 
 .swagger-ui .opblock .body-param .body-param-options label {
@@ -1212,6 +1230,12 @@
   color: var(--red-600);
 }
 
+.swagger-ui .models button {
+  border: none;
+  width: 100%;
+  display: block;
+  padding: 0;
+}
 
 .swagger-ui section.models .flex-wrapper {
   display: flex;
@@ -1226,7 +1250,8 @@
 }
 
 .swagger-ui section.models .flex-wrapper :first-child {
-  flex: 1
+  flex: 1;
+  text-align: left;
 }
 .swagger-ui section.models .flex-wrapper svg {
   transition: all .4s;

--- a/src/styles.css
+++ b/src/styles.css
@@ -631,6 +631,10 @@
   border-radius: 0;
   border-bottom-width: 1px;
 }
+.swagger-ui button.opblock-tag.opblock-tag-btn:focus,
+.swagger-ui button.opblock-tag.opblock-tag-btn:active {
+  border: none;
+}
 
 .swagger-ui .opblock .body-param .body-param-options label {
   display: flex;


### PR DESCRIPTION
replaces with more semantic elements and updates stylings.

## Before
<img width="1751" alt="image" src="https://user-images.githubusercontent.com/2126677/191355965-a4c3f5ed-710a-4302-83d6-1e0a6a90cd85.png">

## After
<img width="1707" alt="image" src="https://user-images.githubusercontent.com/2126677/191356008-0240deee-2998-4e30-945b-1da803884059.png">
