### PR TITLE
refactor: use svg tag instead of after styling for model arrow (TDX-2…

### DIFF
--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -67,7 +67,7 @@ export default class ModelCollapse extends Component {
             >
               {title ? title : null}
               <span className={"toggle-model-icon" + (this.state.expanded ? "" : " collapsed")}>
-                <svg className={"arrow" + (this.state.expanded && title ? " opened" : "")} width="12" height="12" role="img">
+                <svg className={"arrow" + (this.state.expanded && title ? " opened" : "")} width="12" height="12">
                   <use href={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} xlinkHref={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} />
                 </svg>
               </span>

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -67,7 +67,7 @@ export default class ModelCollapse extends Component {
             >
               {title ? title : null}
               <span className={"toggle-model-icon" + (this.state.expanded ? "" : " collapsed")}>
-                <svg className={"arrow" + (this.state.expanded && title ? " opened" : "")} width="12" height="12">
+                <svg className={"arrow" + (this.state.expanded && title ? " opened" : "")} width="12" height="12" role="img">
                   <use href={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} xlinkHref={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} />
                 </svg>
               </span>

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -67,7 +67,7 @@ export default class ModelCollapse extends Component {
             >
               {title ? title : null}
               <span className={"toggle-model-icon" + (this.state.expanded ? "" : " collapsed")}>
-                <svg className={"arrow" + (this.state.expanded ? " opened" : "")} width="12" height="12">
+                <svg className={"arrow" + (this.state.expanded && title ? " opened" : "")} width="12" height="12">
                   <use href={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} xlinkHref={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} />
                 </svg>
               </span>

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -50,7 +50,7 @@ export default class ModelCollapse extends Component {
   }
 
   render() {
-    const { title, classes } = this.props
+    const { title, classes, displayName } = this.props
 
 
     return (
@@ -59,6 +59,7 @@ export default class ModelCollapse extends Component {
           <div>
             <div
               role="button"
+              title={displayName ? `Show ${displayName} model` : 'Show model'}
               aria-pressed={this.state.expanded}
               onClick={this.toggleCollapsed}
               onKeyUp={(e) => this.handleKeypress(e)}

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -66,7 +66,11 @@ export default class ModelCollapse extends Component {
               style={{ "cursor": "pointer", "display": "inline-block" }}
             >
               {title ? title : null}
-              <span className={"model-toggle" + (this.state.expanded ? "" : " collapsed")}></span>
+              <span className={"toggle-model-icon" + (this.state.expanded ? "" : " collapsed")}>
+                <svg className={"arrow" + (this.state.expanded ? " opened" : "")} width="12" height="12">
+                  <use href={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} xlinkHref={this.state.expanded ? "#large-arrow-down" : "#large-arrow"} />
+                </svg>
+              </span>
             </div>
             {this.state.expanded ? this.props.children : this.state.collapsedContent}
           </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1241,6 +1241,10 @@
   padding: 0;
 }
 
+.swagger-ui .toggle-model-icon .arrow.opened {
+  margin-left: 10px;
+}
+
 .swagger-ui section.models .flex-wrapper {
   display: flex;
   font-size: 16px;


### PR DESCRIPTION
…487)
<img width="317" alt="Screen Shot 2022-09-28 at 10 04 23 AM" src="https://user-images.githubusercontent.com/40131297/192829451-575e7a7e-6a76-429c-a8a9-ead6f358373b.png">

Refactors to use an actual svg instead of the `:after` styling