### PR TITLE
chore(a11y): change pressed to expanded attributes (TDX-2579)(TDX-2578)

### DIFF
--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -60,7 +60,7 @@ export default class ModelCollapse extends Component {
             <div
               role="button"
               title={displayName ? `Show ${displayName} model` : 'Show model'}
-              aria-pressed={this.state.expanded}
+              aria-expanded={this.state.expanded}
               onClick={this.toggleCollapsed}
               onKeyUp={(e) => this.handleKeypress(e)}
               tabIndex={0}

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -50,7 +50,7 @@ export default class Models extends Component {
       <button
         className="btn"
         type="button"
-        aria-pressed={showModels}
+        aria-expanded={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
       >
         <div className="flex-wrapper">

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -160,6 +160,7 @@ export default class SidebarList extends React.Component {
             <li className={"submenu" + this.ifActive(this.isTagActive(tag))} >
               <span
                 role="button"
+                aria-expanded={this.isTagActive(tag)}
                 className="submenu-title" tabIndex={0}
                 onClick={() => this.subMenuClicked(tag)}
                 onKeyUp={(e) => this.subMenuKeyup(e.key, tag)}


### PR DESCRIPTION
Small a11y improvements 
- Updated the `aria-pressed` attribute to be `aria-expanded` instead, since they were collapsible.
- Added to the sidebar menu, as it was previously missing the attribute.