### PR TITLE
feat: trap focus inside auth modal when open (TDX-2576)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@braintree/sanitize-url": "^2.0.2",
     "@kyleshockey/xml": "^1.0.2",
     "curl-to-har": "^1.0.1",
+    "focus-trap-react": "^10.0.0",
     "immutable": "^3.x.x",
     "js-file-download": "^0.4.1",
     "memoizee": "^0.4.12",

--- a/src/components/auth/authorization-popup.js
+++ b/src/components/auth/authorization-popup.js
@@ -1,4 +1,5 @@
 import React from "react"
+import FocusTrap from "focus-trap-react"
 import PropTypes from "prop-types"
 
 export default class AuthorizationPopup extends React.Component {
@@ -13,10 +14,24 @@ export default class AuthorizationPopup extends React.Component {
     }
   }
 
-  componentDidMount() {
-    if (this.headerRef ) {
+  handleEscapeClose = (event) => {
+    if (event.code === 'Escape') {
+      this.close()
+    }
+  }
+
+  componentDidMount(){
+    if (this.headerRef) {
       setTimeout(() => {this.headerRef.focus()}, 100)
     }
+    // The keyup event listener is used on the document to capture all possible escape
+    // clicks inside the modal. Before, it was occasionally not firing maybe due to 
+    // a listener on one of the components inside.
+    document.addEventListener("keyup", this.handleEscapeClose)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keyup", this.handleEscapeClose)
   }
 
   render() {
@@ -24,42 +39,44 @@ export default class AuthorizationPopup extends React.Component {
     let definitions = authSelectors.shownDefinitions()
     const Auths = getComponent("auths")
     return (
-      <div className="dialog-ux" onKeyUp={({key}) => {
-        if (key === 'Escape') return this.close()
-      }}>
+      <div className="dialog-ux">
         <div className="backdrop-ux"></div>
-        <div className="modal-ux">
-          <div className="modal-dialog-ux">
-            <div className="modal-ux-inner">
-              <div className="modal-ux-header">
-                <h3
-                tabIndex="0"
-                ref={(_el) => this.headerRef = _el}
-                >Available authorizations</h3>
-                <button type="button" className="close-modal" onClick={ this.close }>
-                  <svg width="20" height="20">
-                    <use href="#close" xlinkHref="#close" />
-                  </svg>
-                </button>
-              </div>
-              <div className="modal-ux-content">
-                {
-                  definitions.valueSeq().map(( definition, key ) => {
-                    return <Auths key={ key }
-                      AST={AST}
-                      definitions={ definition }
-                      getComponent={ getComponent }
-                      errSelectors={ errSelectors }
-                      authSelectors={ authSelectors }
-                      authActions={ authActions }
-                      specSelectors={ specSelectors }
-                    />
-                  })
-                }
+        <FocusTrap>
+          <div className="modal-ux">
+            <div className="modal-dialog-ux">
+              <div className="modal-ux-inner">
+                <div className="modal-ux-header">
+                  <h3
+                    tabIndex="0"
+                    ref={(_el) => this.headerRef = _el}
+                  >
+                    Available authorizations
+                  </h3>
+                  <button type="button" className="close-modal" onClick={ this.close }>
+                    <svg width="20" height="20">
+                      <use href="#close" xlinkHref="#close" />
+                    </svg>
+                  </button>
+                </div>
+                <div className="modal-ux-content">
+                  {
+                    definitions.valueSeq().map(( definition, key ) => {
+                      return <Auths key={ key }
+                        AST={AST}
+                        definitions={ definition }
+                        getComponent={ getComponent }
+                        errSelectors={ errSelectors }
+                        authSelectors={ authSelectors }
+                        authActions={ authActions }
+                        specSelectors={ specSelectors }
+                      />
+                    })
+                  }
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        </FocusTrap>
       </div>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,6 +2378,21 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-react@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-10.0.0.tgz#9e41ddd0b869db577dfe670611648d97736b9188"
+  integrity sha512-I0tReLdpmCwWuVb6YAmOD+S9KHj0GrlIWmnVJf61j2NHxiIg7DbrsabPmtPC+1yzGJrsy+/iTZiqXtStjlBQcA==
+  dependencies:
+    focus-trap "^7.0.0"
+    tabbable "^6.0.0"
+
+focus-trap@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.0.0.tgz#4e2cd9aab5b673e2cbad945c52bd232f6160c2cb"
+  integrity sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==
+  dependencies:
+    tabbable "^6.0.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -4372,6 +4387,11 @@ supports-color@^6.1.0:
   dependencies:
     json-schema-instantiator "0.4.4"
     rollup-plugin-babel "^3.0.3"
+
+tabbable@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.0.tgz#7f95ea69134e9335979092ba63866fe67b521b01"
+  integrity sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Uses a `FocusTrap` library (let me know if others disagree with this usage). Checked and it doesn't look like there are any vulnerabilities with this package.

In addition to adding this package to trap focus, made an improvement on the closing of the modal with `Escape` keypress. This change adds a listener to the document when this component is mounted, and removes the listener when unmounting. This will prevent any issues with the listener colliding with any of the listeners on the focused elements inside of the modal.

https://user-images.githubusercontent.com/40131297/198421118-4dd08dbd-73c5-4eb2-90aa-1d80290fe9c5.mov

