### PR TITLE
chore: minor a11y label adjustments

### DIFF
--- a/src/components/DeepLink.js
+++ b/src/components/DeepLink.js
@@ -11,7 +11,7 @@ export const DeepLink = ({ enabled, path, text, showArrow, isShown }) => {
     <a 
       className={showArrow ? "nostyle has-arrow" : "nostyle"}
       onClick={enabled ? (e) => e.preventDefault() : null}
-      title={showArrow ? isShown ? "Collapse operation": "Expand operation" : null}
+      label={showArrow ? isShown ? `Collapse ${text} operation`: `Expand ${text} operation` : null}
       aria-expanded={showArrow ? isShown : null}
       href={enabled ? `#/${path}` : null}
     >

--- a/src/components/ModelCollapse.js
+++ b/src/components/ModelCollapse.js
@@ -59,7 +59,7 @@ export default class ModelCollapse extends Component {
           <div>
             <div
               role="button"
-              title={displayName ? `Show ${displayName} model` : 'Show model'}
+              aria-label={displayName ? `${this.state.expanded ? "Hide" : "Show"} ${displayName} model` : `${this.state.expanded ? "Hide" : "Show"} model`}
               aria-expanded={this.state.expanded}
               onClick={this.toggleCollapsed}
               onKeyUp={(e) => this.handleKeypress(e)}

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -50,6 +50,7 @@ export default class Models extends Component {
       <button
         className="btn"
         type="button"
+        aria-label={showModels ? `Collapse ${isOAS3 ? "Schemas" : "Models"}` : `Expand ${isOAS3 ? "Schemas" : "Models"}`}
         aria-expanded={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
       >

--- a/src/components/OperationTag.js
+++ b/src/components/OperationTag.js
@@ -42,6 +42,7 @@ export default class OperationTag extends React.Component {
         <button
           type="button"
           aria-expanded={showTag}
+          aria-label={showTag ? `Collapse ${tagDescription ? `${tag} (${tagDescription})` : `${tag}`} operation section` :`Expand ${tagDescription ? `${tag} (${tagDescription})` : `${tag}`} operation section`}
           className={'btn opblock-tag-btn ' + (!tagDescription ? "opblock-tag no-desc" : "opblock-tag") }
           id={opBlockSectionKeyId}
           aria-controls={opBlockSectionCollapseKeyId}

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -161,6 +161,7 @@ export default class SidebarList extends React.Component {
               <span
                 role="button"
                 aria-expanded={this.isTagActive(tag)}
+                aria-label={this.isTagActive(tag) ? `Collapse ${tag} section` : `Expand ${tag} section`}
                 className="submenu-title" tabIndex={0}
                 onClick={() => this.subMenuClicked(tag)}
                 onKeyUp={(e) => this.subMenuKeyup(e.key, tag)}

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -23,7 +23,7 @@ export class ParameterRowError extends Component {
     ) {
       setTimeout(() => {
         // Get the first invalid input
-        const associatedInput = this.el.parentElement?.parentElement?.parentElement?.querySelector('input.invalid')
+        const associatedInput = this.el.closest('table.parameters')?.querySelector('input.invalid')
 
         if (associatedInput) {
           associatedInput.focus()
@@ -38,7 +38,7 @@ export class ParameterRowError extends Component {
 
   render() {
     const { errors, param } = this.props
-    const associatedInput = this.el?.parentElement?.parentElement?.parentElement?.querySelector('input.invalid')
+    const associatedInput = this.el?.closest('table.parameters')?.querySelector('input.invalid')
 
 
     return (


### PR DESCRIPTION
Various improvements applied (DWP mentioned in their call that some buttons announce their current state, but don't announce what it'll do e.g. expand if you're already collapsed)

