### PR TITLE
fix(authroize): fixes checkboxes so they display correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -190,9 +190,11 @@ textarea {
     }
 
     &:checked + label > .item {
-      background: $form-checkbox-background-color
-        url('data:image/svg+xml, <svg width="10px" height="8px" viewBox="3 7 10 8" version="1.1" xmlns="http://www.w3.org/2000/svg"><polygon id="Rectangle-34" stroke="none" fill="#41474E" fill-rule="evenodd" points="6.33333333 15 3 11.6666667 4.33333333 10.3333333 6.33333333 12.3333333 11.6666667 7 13 8.33333333"></polygon></svg>')
-        center center no-repeat;
+      background-color: $form-checkbox-background-color;
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjMDAwMDAwIiBkPSJNMTczLjg5OCA0MzkuNDA0bC0xNjYuNC0xNjYuNGMtOS45OTctOS45OTctOS45OTctMjYuMjA2IDAtMzYuMjA0bDM2LjIwMy0zNi4yMDRjOS45OTctOS45OTggMjYuMjA3LTkuOTk4IDM2LjIwNCAwTDE5MiAzMTIuNjkgNDMyLjA5NSA3Mi41OTZjOS45OTctOS45OTcgMjYuMjA3LTkuOTk3IDM2LjIwNCAwbDM2LjIwMyAzNi4yMDRjOS45OTcgOS45OTcgOS45OTcgMjYuMjA2IDAgMzYuMjA0bC0yOTQuNCAyOTQuNDAxYy05Ljk5OCA5Ljk5Ny0yNi4yMDcgOS45OTctMzYuMjA0LS4wMDF6Ii8+PC9zdmc+);
+      background-size: 16px 16px;
+      background-position: center;
+      background-repeat: no-repeat;
     }
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -133,9 +133,10 @@
 }
 
 .swagger-ui .auth-btn-wrapper {
-  justify-content: start;
+  justify-content: space-between;
   margin-top: 1rem;
-
+  padding: 10px 20px 10px 0;
+  
   button {
     box-shadow: none;
   }


### PR DESCRIPTION
This PR fixes the authorize modal's checkboxes so they are now clickable. 
I ended up changing the SVG, as something with the svg being used made it not work when we increased the size of the checkboxes.  I also broke it into multilines instead of shorthand, as it's quite long with `url()`

Also changed the spacing between authorize and close buttons
