### PR TITLE
style: fix styling for when there is no spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.0.9",
+  "version": "4.1.0",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -230,23 +230,14 @@ export default class KongLayout extends React.Component {
 
           {!hasSpec ? (
             <div className={styles.container}>
-              <div className="info">
-                {serviceDoc &&
-                  <div
-                    className='service-package-markdown markdown-body'
-                    dangerouslySetInnerHTML={{ __html: serviceDoc }}>
-                  </div>
-                }
-              </div>
-
               <div
                 data-testid="spec-error-state"
-                className="mt-7 text-center">
-                <div className="d-flex justify-content-center mb-5">
+                className={styles.errorContainer}>
+                <div>
                   <ErrorSVG />
                 </div>
-                <p className="text-center color-text_colors-primary mb-2">No version spec found</p>
-                <p className="text-center">
+                <p>No version spec found</p>
+                <p>
                   <a
                     href="/"
                     data-testid="spec-error-catalog-link"

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -131,14 +131,8 @@ export default class KongLayout extends React.Component {
 
     const config = getConfigs()
 
-    const versionDeprecated = config.versionDeprecated
-
     const {
-      serviceDoc,
       hasSidebar,
-      defaultServiceVersionId,
-      deprecatedCopy,
-      serviceVersions,
       applicationRegistrationEnabled
     } = config.theme || {}
 
@@ -216,7 +210,6 @@ export default class KongLayout extends React.Component {
         <div className={'px-6 swagger-ui ' + (hasSidebar && 'has-sidebar')}>
           <div className={styles.schemeContainer}>
             <div className="schemes wrapper align-items-center px-0 flex-col">
-              {versionDeprecated ? <p className="deprecated-alert w-full mt-1 mb-3">{deprecatedCopy}</p> : null}
               <div className={`actions d-flex ${actionBarJustification} align-items-center w-full mt-3 mb-3`}>
                 {actionBarItems}
               </div>

--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -19,6 +19,13 @@
   margin: var(--layout-container-margin);
 }
 
+.error-container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--spacing-xxl, 48px);
+}
+
 .scheme-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Reduces the use of tailwind classes, and also removed a div that will no longer be rendered (since there is no service doc)