### PR TITLE
feat(a11y): add error to document if errors are present (TDX-2839)

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -21,6 +21,32 @@ class RegisterBtnContainer extends React.Component {
 
 // Create the layout component
 export default class KongLayout extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.mainContainerRef = null
+    this.originalDocumentTitle = null
+  }
+
+  initializeComponent = (component) => {
+    this.mainContainerRef = component
+  }
+
+  componentDidMount() {
+    this.originalDocumentTitle = document.title
+  }
+
+  componentDidUpdate() {
+    // Find if there's any invalid parameters
+    const hasInvalidParameters = this.mainContainerRef?.querySelector('.error-parameter-name')
+
+    if (hasInvalidParameters) {
+      document.title = `Error - ${this.originalDocumentTitle}`
+    } else {
+      document.title = this.originalDocumentTitle
+    }
+  }
+
   render() {
     const {
       errSelectors,
@@ -125,7 +151,7 @@ export default class KongLayout extends React.Component {
             </div>
 
             <Errors />
-            <div className="main-container">
+            <div className="main-container" ref={this.initializeComponent}>
               <InfoContainer />
               <Operations />
               <Models />

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -46,7 +46,7 @@ export default class ParameterRow extends Component {
 
     let enumValue
 
-    if(isOAS3) {
+    if (isOAS3) {
       let { schema } = getParameterSchema(parameterWithMeta, { isOAS3 })
       enumValue = schema ? schema.get("enum") : undefined
     } else {
@@ -56,13 +56,13 @@ export default class ParameterRow extends Component {
 
     let value
 
-    if ( paramValue !== undefined ) {
+    if (paramValue !== undefined) {
       value = paramValue
-    } else if ( rawParam.get("required") && enumValue && enumValue.size ) {
+    } else if (rawParam.get("required") && enumValue && enumValue.size) {
       value = enumValue.first()
     }
 
-    if ( value !== undefined && value !== paramValue ) {
+    if (value !== undefined && value !== paramValue) {
       this.onChangeWrapper(numberToString(value))
     }
     // todo: could check if schema here; if not, do not call. impact?
@@ -74,7 +74,7 @@ export default class ParameterRow extends Component {
     let valueForUpstream
 
     // Coerce empty strings and empty Immutable objects to null
-    if(value === "" || (value && value.size === 0)) {
+    if (value === "" || (value && value.size === 0)) {
       valueForUpstream = null
     } else {
       valueForUpstream = value
@@ -118,7 +118,7 @@ export default class ParameterRow extends Component {
       return
     }
 
-    if( paramWithMeta.get("in") !== "body" ) {
+    if (paramWithMeta.get("in") !== "body") {
       let initialValue
 
       //// Find an initial value
@@ -139,16 +139,16 @@ export default class ParameterRow extends Component {
 
       //// Process the initial value
 
-      if(initialValue !== undefined && !List.isList(initialValue)) {
+      if (initialValue !== undefined && !List.isList(initialValue)) {
         // Stringify if it isn't a List
         initialValue = stringify(initialValue)
       }
 
       //// Dispatch the initial value
 
-      if(initialValue !== undefined) {
+      if (initialValue !== undefined) {
         this.onChangeWrapper(initialValue)
-      } else if(
+      } else if (
         schema && schema.get("type") === "object"
         && generatedSampleValue
         && !paramWithMeta.get("examples")
@@ -172,7 +172,7 @@ export default class ParameterRow extends Component {
   getParamKey() {
     const { param } = this.props
 
-    if(!param) return null
+    if (!param) return null
 
     return `${param.get("name")}-${param.get("in")}`
   }
@@ -183,17 +183,17 @@ export default class ParameterRow extends Component {
   }
 
   render() {
-    let {param, rawParam, getComponent, getConfigs, isExecute, fn, onChangeConsumes, specSelectors, pathMethod, specPath, oas3Selectors} = this.props
+    let { param, rawParam, getComponent, getConfigs, isExecute, fn, onChangeConsumes, specSelectors, pathMethod, specPath, oas3Selectors } = this.props
 
     let isOAS3 = specSelectors.isOAS3()
 
     const { showExtensions, showCommonExtensions } = getConfigs()
 
-    if(!param) {
+    if (!param) {
       param = rawParam
     }
 
-    if(!rawParam) return null
+    if (!rawParam) return null
 
     // const onChangeWrapper = (value) => onChange(param, value)
     const JsonSchemaForm = getComponent("JsonSchemaForm")
@@ -201,15 +201,15 @@ export default class ParameterRow extends Component {
     let inType = param.get("in")
     let bodyParam = inType !== "body" ? null
       : <ParamBody getComponent={getComponent}
-                   fn={fn}
-                   param={param}
-                   consumes={ specSelectors.consumesOptionsFor(pathMethod) }
-                   consumesValue={ specSelectors.contentTypeValues(pathMethod).get("requestContentType") }
-                   onChange={this.onChangeWrapper}
-                   onChangeConsumes={onChangeConsumes}
-                   isExecute={ isExecute }
-                   specSelectors={ specSelectors }
-                   pathMethod={ pathMethod }
+        fn={fn}
+        param={param}
+        consumes={specSelectors.consumesOptionsFor(pathMethod)}
+        consumesValue={specSelectors.contentTypeValues(pathMethod).get("requestContentType")}
+        onChange={this.onChangeWrapper}
+        onChangeConsumes={onChangeConsumes}
+        isExecute={isExecute}
+        specSelectors={specSelectors}
+        pathMethod={pathMethod}
       />
 
     const ModelExample = getComponent("modelExample")
@@ -239,7 +239,7 @@ export default class ParameterRow extends Component {
     let paramExample // undefined
     let isDisplayParamEnum = false
 
-    if ( param !== undefined && schema ) {
+    if (param !== undefined && schema) {
       paramItems = schema.get("items")
     }
 
@@ -250,12 +250,12 @@ export default class ParameterRow extends Component {
       paramEnum = schema.get("enum")
     }
 
-    if ( paramEnum && paramEnum.size && paramEnum.size > 0) {
+    if (paramEnum && paramEnum.size && paramEnum.size > 0) {
       isDisplayParamEnum = true
     }
 
     // Default and Example Value for readonly doc
-    if ( param !== undefined ) {
+    if (param !== undefined) {
       if (schema) {
         paramDefaultValue = schema.get("default")
       }
@@ -272,35 +272,35 @@ export default class ParameterRow extends Component {
       <tr data-param-name={param.get("name")} data-param-in={param.get("in")}>
         <td className="parameters-col_name">
           <div className={required ? "parameter__name required" : "parameter__name"}>
-            { param.get("name") }
-            { !required ? null : <span style={{color: "red"}}>&nbsp;*</span> }
+            {param.get("name")}
+            {!required ? null : <span style={{ color: "red" }}>&nbsp;*</span>}
           </div>
           <div className="parameter__type">
-            { type }
-            { itemType && `[${itemType}]` }
-            { format && <span className="prop-format">(${format})</span>}
+            {type}
+            {itemType && `[${itemType}]`}
+            {format && <span className="prop-format">(${format})</span>}
           </div>
           <div className="parameter__deprecated">
-            { isOAS3 && param.get("deprecated") ? "deprecated": null }
+            {isOAS3 && param.get("deprecated") ? "deprecated" : null}
           </div>
-          <div className="parameter__in">({ param.get("in") })</div>
-          { !showCommonExtensions || !commonExt.size ? null : commonExt.map((v, key) => <ParameterExt key={`${key}-${v}`} xKey={key} xVal={v} /> )}
-          { !showExtensions || !extensions.size ? null : extensions.map((v, key) => <ParameterExt key={`${key}-${v}`} xKey={key} xVal={v} /> )}
+          <div className="parameter__in">({param.get("in")})</div>
+          {!showCommonExtensions || !commonExt.size ? null : commonExt.map((v, key) => <ParameterExt key={`${key}-${v}`} xKey={key} xVal={v} />)}
+          {!showExtensions || !extensions.size ? null : extensions.map((v, key) => <ParameterExt key={`${key}-${v}`} xKey={key} xVal={v} />)}
         </td>
 
         <td className="parameters-col_description">
-          { param.get("description") ? <Markdown source={ param.get("description") }/> : null }
+          {param.get("description") ? <Markdown source={param.get("description")} /> : null}
 
-          { (bodyParam || !isExecute) && isDisplayParamEnum ?
+          {(bodyParam || !isExecute) && isDisplayParamEnum ?
             <Markdown className="parameter__enum" source={
-                "<i>Available values</i> : " + paramEnum.map(function(item) {
-                    return item
-                  }).toArray().join(", ")}/>
+              "<i>Available values</i> : " + paramEnum.map(function (item) {
+                return item
+              }).toArray().join(", ")} />
             : null
           }
 
-          { (bodyParam || !isExecute) && paramDefaultValue !== undefined ?
-            <Markdown className="parameter__default" source={"<i>Default value</i> : " + paramDefaultValue}/>
+          {(bodyParam || !isExecute) && paramDefaultValue !== undefined ?
+            <Markdown className="parameter__default" source={"<i>Default value</i> : " + paramDefaultValue} />
             : null
           }
 
@@ -322,41 +322,41 @@ export default class ParameterRow extends Component {
             ) : null
           }
 
-          { bodyParam ? null
+          {bodyParam ? null
             : <JsonSchemaForm fn={fn}
-                              getComponent={getComponent}
-                              value={ value }
-                              required={ required }
-                              disabled={!isExecute}
-                              description={param.get("description") ? `${param.get("name")} - ${param.get("description")}` : `${param.get("name")}`}
-                              onChange={ this.onChangeWrapper }
-                              errors={ paramWithMeta.get("errors") }
-                              schema={ schema }/>
+              getComponent={getComponent}
+              value={value}
+              required={required}
+              disabled={!isExecute}
+              description={param.get("description") ? `${param.get("name")} - ${param.get("description")}` : `${param.get("name")}`}
+              onChange={this.onChangeWrapper}
+              errors={paramWithMeta.get("errors")}
+              schema={schema} />
           }
 
           {/* Kong change -  Display error message in case of errors */}
-          { bodyParam ? null
+          {bodyParam ? null
             : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
           }
 
           {
-            bodyParam && schema ? <ModelExample getComponent={ getComponent }
-                                                specPath={specPath.push("schema")}
-                                                getConfigs={ getConfigs }
-                                                isExecute={ isExecute }
-                                                specSelectors={ specSelectors }
-                                                schema={ schema }
-                                                example={ bodyParam }/>
+            bodyParam && schema ? <ModelExample getComponent={getComponent}
+              specPath={specPath.push("schema")}
+              getConfigs={getConfigs}
+              isExecute={isExecute}
+              specSelectors={specSelectors}
+              schema={schema}
+              example={bodyParam} />
               : null
           }
 
           {
             !bodyParam && isExecute && param.get("allowEmptyValue") ?
-            <ParameterIncludeEmpty
-              onChange={this.onChangeIncludeEmpty}
-              isIncluded={specSelectors.parameterInclusionSettingFor(pathMethod, param.get("name"), param.get("in"))}
-              isDisabled={!isEmptyValue(value)} />
-            : null
+              <ParameterIncludeEmpty
+                onChange={this.onChangeIncludeEmpty}
+                isIncluded={specSelectors.parameterInclusionSettingFor(pathMethod, param.get("name"), param.get("in"))}
+                isDisabled={!isEmptyValue(value)} />
+              : null
           }
 
           {


### PR DESCRIPTION
This adds a listener to the layout, where it will change the document's title if there are errors present in the page. If a section is closed, it will update it back to the original, and if the error is still present when it is re-opened, it will be updated again.