### PR TITLE
fix(a11y): remove unnecessary roles (TDX-2837)

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -7,7 +7,7 @@ import React, { Component } from "react"
 import PropTypes from "prop-types"
 
 const NoMargin = ({ children, id, labelledBy }) => {
-  return <div id={id} aria-labelledby={labelledBy} role="region" style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
+  return <div id={id} aria-labelledby={labelledBy} style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
 }
 
 NoMargin.propTypes = {

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -154,8 +154,8 @@ export default class SidebarList extends React.Component {
     return (
       <div className="spec sidebar-list" id="spec-sidebar-list">
         <ul>
-          <li role="none" className="spec list-title">Resources</li>
-          <li role="none"><FilterContainer /></li>
+          <li className="spec list-title">Resources</li>
+          <li><FilterContainer /></li>
           {this.state.filteredSidebarData.map((sidebarItem, tag) =>
             <li className={"submenu" + this.ifActive(this.isTagActive(tag))} >
               <span


### PR DESCRIPTION
Some roles are being unnecessarily used, causing issues with accessibility. The `region` role was removed from the Collapse component, as well as the `role="none"` in list items part of the sidebar.