### PR TITLE
fix(a11y): adjust heading levels to make more sense (TDX-2840)

### DIFF
--- a/src/components/LiveResponse.js
+++ b/src/components/LiveResponse.js
@@ -1,0 +1,128 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/live-response.jsx
+ * @prettier
+ */
+
+import React from "react"
+import PropTypes from "prop-types"
+import ImPropTypes from "react-immutable-proptypes"
+
+const Headers = ({ headers }) => {
+  return (
+    <div>
+      <h5>Response headers</h5>
+      <pre className="microlight">{headers}</pre>
+    </div>)
+}
+Headers.propTypes = {
+  headers: PropTypes.array.isRequired
+}
+
+const Duration = ({ duration }) => {
+  return (
+    <div>
+      <h5>Request duration</h5>
+      <pre className="microlight">{duration} ms</pre>
+    </div>
+  )
+}
+Duration.propTypes = {
+  duration: PropTypes.number.isRequired
+}
+
+
+export default class LiveResponse extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    // BUG: props.response is always coming back as a new Immutable instance
+    // same issue as responses.jsx (tryItOutResponse)
+    return this.props.response !== nextProps.response
+      || this.props.path !== nextProps.path
+      || this.props.method !== nextProps.method
+      || this.props.displayRequestDuration !== nextProps.displayRequestDuration
+  }
+
+  render() {
+    const { response, getComponent, getConfigs, displayRequestDuration, specSelectors, path, method } = this.props
+    const { showMutatedRequest } = getConfigs()
+
+    const curlRequest = showMutatedRequest ? specSelectors.mutatedRequestFor(path, method) : specSelectors.requestFor(path, method)
+    const status = response.get("status")
+    const url = curlRequest.get("url")
+    const headers = response.get("headers").toJS()
+    const notDocumented = response.get("notDocumented")
+    const isError = response.get("error")
+    const body = response.get("text")
+    const duration = response.get("duration")
+    const headersKeys = Object.keys(headers)
+    const contentType = headers["content-type"] || headers["Content-Type"]
+
+    const Curl = getComponent("curl")
+    const ResponseBody = getComponent("responseBody")
+    const returnObject = headersKeys.map(key => {
+      return <span className="headerline" key={key}> {key}: {headers[key]} </span>
+    })
+    const hasHeaders = returnObject.length !== 0
+
+    return (
+      <div>
+        {curlRequest && <Curl request={curlRequest} />}
+        {url && <div>
+          <h3>Request URL</h3>
+          <div className="request-url">
+            <pre className="microlight">{url}</pre>
+          </div>
+        </div>
+        }
+        <h3>Server response</h3>
+        <table className="responses-table live-responses-table">
+          <thead>
+            <tr className="responses-header">
+              <td className="col_header response-col_status">Code</td>
+              <td className="col_header response-col_description">Details</td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="response">
+              <td className="response-col_status">
+                {status}
+                {
+                  notDocumented ? <div className="response-undocumented">
+                    <i> Undocumented </i>
+                  </div>
+                    : null
+                }
+              </td>
+              <td className="response-col_description">
+                {
+                  isError ? <span>
+                    {`${response.get("name")}: ${response.get("message")}`}
+                  </span>
+                    : null
+                }
+                {
+                  body ? <ResponseBody content={body}
+                    contentType={contentType}
+                    url={url}
+                    headers={headers}
+                    getComponent={getComponent} />
+                    : null
+                }
+                {
+                  hasHeaders ? <Headers headers={returnObject} /> : null
+                }
+                {
+                  displayRequestDuration && duration ? <Duration duration={duration} /> : null
+                }
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  static propTypes = {
+    getComponent: PropTypes.func.isRequired,
+    response: ImPropTypes.map
+  }
+}

--- a/src/components/Parameters.js
+++ b/src/components/Parameters.js
@@ -122,8 +122,8 @@ export default class Parameters extends Component {
               <table className="parameters">
                 <thead>
                   <tr>
-                    <th className="col_header parameters-col_name">Name</th>
-                    <th className="col_header parameters-col_description">Description</th>
+                    <th className="col_header parameters-col_name" scope="col">Name</th>
+                    <th className="col_header parameters-col_description" scope="col">Description</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/components/Parameters.js
+++ b/src/components/Parameters.js
@@ -1,0 +1,223 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/parameters/parameters.jsx
+ * @prettier
+ */
+
+import React, { Component } from "react"
+import Im, { Map, List } from "immutable"
+
+// More readable, just iterate over maps, only
+const eachMap = (iterable, fn) => iterable.valueSeq().filter(Im.Map.isMap).map(fn)
+
+export default class Parameters extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      callbackVisible: false,
+      parametersVisible: true
+    }
+  }
+
+
+  static defaultProps = {
+    onTryoutClick: Function.prototype,
+    onCancelClick: Function.prototype,
+    tryItOutEnabled: false,
+    allowTryItOut: true,
+    onChangeKey: [],
+    specPath: [],
+  }
+
+  onChange = (param, value, isXml) => {
+    let {
+      specActions: { changeParamByIdentity },
+      onChangeKey,
+    } = this.props
+
+    changeParamByIdentity(onChangeKey, param, value, isXml)
+  }
+
+  onChangeConsumesWrapper = (val) => {
+    let {
+      specActions: { changeConsumesValue },
+      onChangeKey
+    } = this.props
+
+    changeConsumesValue(onChangeKey, val)
+  }
+
+  toggleTab = (tab) => {
+    if (tab === "parameters") {
+      return this.setState({
+        parametersVisible: true,
+        callbackVisible: false
+      })
+    } else if (tab === "callbacks") {
+      return this.setState({
+        callbackVisible: true,
+        parametersVisible: false
+      })
+    }
+  }
+
+  render() {
+
+    let {
+      onTryoutClick,
+      onCancelClick,
+      parameters,
+      allowTryItOut,
+      tryItOutEnabled,
+      specPath,
+
+      fn,
+      getComponent,
+      getConfigs,
+      specSelectors,
+      specActions,
+      pathMethod,
+      oas3Actions,
+      oas3Selectors,
+      operation
+    } = this.props
+
+    const ParameterRow = getComponent("parameterRow")
+    const TryItOutButton = getComponent("TryItOutButton")
+    const ContentType = getComponent("contentType")
+    const Callbacks = getComponent("Callbacks", true)
+    const RequestBody = getComponent("RequestBody", true)
+
+    const isExecute = tryItOutEnabled && allowTryItOut
+    const isOAS3 = specSelectors.isOAS3()
+
+    const requestBody = operation.get("requestBody")
+    return (
+      <section className="opblock-section">
+        <div className="opblock-section-header">
+          {isOAS3 ? (
+            <div className="tab-header">
+              <div onClick={() => this.toggleTab("parameters")} className={`tab-item ${this.state.parametersVisible && "active"}`}>
+                <h3 className="opblock-title"><span>Parameters</span></h3>
+              </div>
+              {operation.get("callbacks") ?
+                (
+                  <div onClick={() => this.toggleTab("callbacks")} className={`tab-item ${this.state.callbackVisible && "active"}`}>
+                    <h3 className="opblock-title"><span>Callbacks</span></h3>
+                  </div>
+                ) : null
+              }
+            </div>
+          ) : (
+            <div className="tab-header">
+              <h3 className="opblock-title">Parameters</h3>
+            </div>
+          )}
+          {allowTryItOut ? (
+            <TryItOutButton enabled={tryItOutEnabled} onCancelClick={onCancelClick} onTryoutClick={onTryoutClick} />
+          ) : null}
+        </div>
+        {this.state.parametersVisible ? <div className="parameters-container">
+          {!parameters.count() ? <div className="opblock-description-wrapper"><p>No parameters</p></div> :
+            <div className="table-container">
+              <table className="parameters">
+                <thead>
+                  <tr>
+                    <th className="col_header parameters-col_name">Name</th>
+                    <th className="col_header parameters-col_description">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {
+                    eachMap(parameters, (parameter, i) => (
+                      <ParameterRow
+                        fn={fn}
+                        specPath={specPath.push(i.toString())}
+                        getComponent={getComponent}
+                        getConfigs={getConfigs}
+                        rawParam={parameter}
+                        param={specSelectors.parameterWithMetaByIdentity(pathMethod, parameter)}
+                        key={`${parameter.get("in")}.${parameter.get("name")}`}
+                        onChange={this.onChange}
+                        onChangeConsumes={this.onChangeConsumesWrapper}
+                        specSelectors={specSelectors}
+                        specActions={specActions}
+                        oas3Actions={oas3Actions}
+                        oas3Selectors={oas3Selectors}
+                        pathMethod={pathMethod}
+                        isExecute={isExecute} />
+                    )).toArray()
+                  }
+                </tbody>
+              </table>
+            </div>
+          }
+        </div> : null}
+
+        {this.state.callbackVisible ? <div className="callbacks-container opblock-description-wrapper">
+          <Callbacks
+            callbacks={Map(operation.get("callbacks"))}
+            specPath={specPath.slice(0, -1).push("callbacks")}
+          />
+        </div> : null}
+        {
+          isOAS3 && requestBody && this.state.parametersVisible &&
+          <div className="opblock-section opblock-section-request-body">
+            <div className="opblock-section-header">
+              <h3 className={`opblock-title parameter__name ${requestBody.get("required") && "required"}`}>Request body</h3>
+              <label>
+                <ContentType
+                  value={oas3Selectors.requestContentType(...pathMethod)}
+                  contentTypes={requestBody.get("content", List()).keySeq()}
+                  onChange={(value) => {
+                    oas3Actions.setRequestContentType({ value, pathMethod })
+                  }}
+                  className="body-param-content-type" />
+              </label>
+            </div>
+            <div className="opblock-description-wrapper">
+              <RequestBody
+                specPath={specPath.slice(0, -1).push("requestBody")}
+                requestBody={requestBody}
+                requestBodyValue={oas3Selectors.requestBodyValue(...pathMethod)}
+                requestBodyInclusionSetting={oas3Selectors.requestBodyInclusionSetting(...pathMethod)}
+                isExecute={isExecute}
+                activeExamplesKey={oas3Selectors.activeExamplesMember(
+                  ...pathMethod,
+                  "requestBody",
+                  "requestBody" // RBs are currently not stored per-mediaType
+                )}
+                updateActiveExamplesKey={key => {
+                  this.props.oas3Actions.setActiveExamplesMember({
+                    name: key,
+                    pathMethod: this.props.pathMethod,
+                    contextType: "requestBody",
+                    contextName: "requestBody" // RBs are currently not stored per-mediaType
+                  })
+                }
+                }
+                onChange={(value, path) => {
+                  if (path) {
+                    const lastValue = oas3Selectors.requestBodyValue(...pathMethod)
+                    const usableValue = Map.isMap(lastValue) ? lastValue : Map()
+                    return oas3Actions.setRequestBodyValue({
+                      pathMethod,
+                      value: usableValue.setIn(path, value)
+                    })
+                  }
+                  oas3Actions.setRequestBodyValue({ value, pathMethod })
+                }}
+                onChangeIncludeEmpty={(name, value) => {
+                  oas3Actions.setRequestBodyInclusion({
+                    pathMethod,
+                    value,
+                    name,
+                  })
+                }}
+                contentType={oas3Selectors.requestContentType(...pathMethod)} />
+            </div>
+          </div>
+        }
+      </section>
+    )
+  }
+}

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -1,0 +1,132 @@
+/**
+ * Original file: https://github.com/Kong/swagger-ui/blob/main/src/core/components/responses.jsx
+ * @prettier
+ */
+
+import React from "react"
+import { fromJS } from "immutable"
+import { defaultStatusCode, getAcceptControllingResponse } from '../helpers/helpers'
+
+export default class Responses extends React.Component {
+  static defaultProps = {
+    tryItOutResponse: null,
+    produces: fromJS(["application/json"]),
+    displayRequestDuration: false
+  }
+
+  onChangeProducesWrapper = (val) => this.props.specActions.changeProducesValue([this.props.path, this.props.method], val)
+
+  onResponseContentTypeChange = ({ controlsAcceptHeader, value }) => {
+    const { oas3Actions, path, method } = this.props
+    if (controlsAcceptHeader) {
+      oas3Actions.setResponseContentType({
+        value,
+        path,
+        method
+      })
+    }
+  }
+
+  render() {
+    let {
+      responses,
+      tryItOutResponse,
+      getComponent,
+      getConfigs,
+      specSelectors,
+      fn,
+      producesValue,
+      displayRequestDuration,
+      specPath,
+      path,
+      method,
+      oas3Selectors,
+      oas3Actions,
+    } = this.props
+    let defaultCode = defaultStatusCode(responses)
+
+    const ContentType = getComponent("contentType")
+    const LiveResponse = getComponent("liveResponse")
+    const Response = getComponent("response")
+
+    let produces = this.props.produces && this.props.produces.size ? this.props.produces : Responses.defaultProps.produces
+
+    const isSpecOAS3 = specSelectors.isOAS3()
+
+    const acceptControllingResponse = isSpecOAS3 ?
+      getAcceptControllingResponse(responses) : null
+
+    return (
+      <div className="responses-wrapper">
+        <div className="opblock-section-header">
+          <h3>Responses</h3>
+          {specSelectors.isOAS3() ? null : <label>
+            <span>Response content type</span>
+            <ContentType value={producesValue}
+              onChange={this.onChangeProducesWrapper}
+              contentTypes={produces}
+              className="execute-content-type" />
+          </label>}
+        </div>
+        <div className="responses-inner">
+          {
+            !tryItOutResponse ? null
+              : <div>
+                <LiveResponse response={tryItOutResponse}
+                  getComponent={getComponent}
+                  getConfigs={getConfigs}
+                  specSelectors={specSelectors}
+                  path={this.props.path}
+                  method={this.props.method}
+                  displayRequestDuration={displayRequestDuration} />
+                <h3>Responses</h3>
+              </div>
+
+          }
+
+          <table className="responses-table">
+            <thead>
+              <tr className="responses-header">
+                <td className="col_header response-col_status">Code</td>
+                <td className="col_header response-col_description">Description</td>
+                {specSelectors.isOAS3() ? <td className="col col_header response-col_links">Links</td> : null}
+              </tr>
+            </thead>
+            <tbody>
+              {
+                responses.entrySeq().map(([code, response]) => {
+
+                  let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
+                  return (
+                    <Response key={code}
+                      path={path}
+                      method={method}
+                      specPath={specPath.push(code)}
+                      isDefault={defaultCode === code}
+                      fn={fn}
+                      className={className}
+                      code={code}
+                      response={response}
+                      specSelectors={specSelectors}
+                      controlsAcceptHeader={response === acceptControllingResponse}
+                      onContentTypeChange={this.onResponseContentTypeChange}
+                      contentType={producesValue}
+                      getConfigs={getConfigs}
+                      activeExamplesKey={oas3Selectors.activeExamplesMember(
+                        path,
+                        method,
+                        "responses",
+                        code
+                      )}
+                      oas3Actions={oas3Actions}
+                      getComponent={getComponent} />
+                  )
+                }).toArray()
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -333,6 +333,36 @@ export function deeplyStripKey(input, keyToStrip, predicate = () => true) {
   return obj
 }
 
+const DEFAULT_RESPONSE_KEY = "default"
+
+export function defaultStatusCode ( responses ) {
+  let codes = responses.keySeq()
+  return codes.contains(DEFAULT_RESPONSE_KEY) ? DEFAULT_RESPONSE_KEY : codes.filter( key => (key+"")[0] === "2").sort().first()
+}
+
+export function getAcceptControllingResponse(responses) {
+  if(!Im.OrderedMap.isOrderedMap(responses)) {
+    // wrong type!
+    return null
+  }
+
+  if(!responses.size) {
+    // responses is empty
+    return null
+  }
+
+  const suitable2xxResponse = responses.find((res, k) => {
+    return k.startsWith("2") && Object.keys(res.get("content") || {}).length > 0
+  })
+
+  // try to find a suitable `default` responses
+  const defaultResponse = responses.get("default") || Im.OrderedMap()
+  const defaultResponseMediaTypes = (defaultResponse.get("content") || Im.OrderedMap()).keySeq().toJS()
+  const suitableDefaultResponse = defaultResponseMediaTypes.length ? defaultResponse : null
+
+  return suitable2xxResponse || suitableDefaultResponse
+}
+
 export const sampleFromSchema = (schema, config={}) => {
   let { type, example, properties, additionalProperties, items } = objectify(schema)
   let { includeReadOnly, includeWriteOnly } = config

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Models from './components/Models'
 import ModelCollapse from './components/ModelCollapse'
 import OperationTag from './components/OperationTag'
 import FilterContainer from './containers/Filter'
+import Parameters from './components/Parameters'
 import Operations from './components/Operations'
 import DeepLink from './components/DeepLink'
 import OperationSummaryPath from './components/OperationSummaryPath'
@@ -24,6 +25,8 @@ import AuthorizationPopup from './components/auth/authorization-popup'
 import AuthorizeBtn from './components/auth/authorize-btn'
 import AuthorizeOperationBtn from './components/auth/authorize-operation-btn'
 import Collapse from './components/Collapse'
+import Responses from './components/Responses'
+import LiveResponse from './components/LiveResponse'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = (system) => {
@@ -78,6 +81,8 @@ const SwaggerUIKongTheme = (system) => {
       operation: Operation,
       OperationSummaryPath,
       DeepLink,
+      parameters: Parameters,
+      liveResponse: LiveResponse,
       FilterContainer: FilterContainer,
       operations: Operations,
       modelExample: ModelExample,
@@ -102,11 +107,11 @@ const SwaggerUIKongTheme = (system) => {
           <AuthorizationPopup {...props} system={system} />
         )
       },
-      responses: (Original, system) => (props) => {
+      responses: (_Original, system) => (props) => {
         return (
           <div className="right-side-wrapper">
             <AugmentingResponses {...props} system={system} />
-            <Original { ...props} />
+            <Responses { ...props} />
           </div>
         )
       },

--- a/src/styles.css
+++ b/src/styles.css
@@ -579,8 +579,12 @@
   background-color: var(--black-400);
 }
 
-.swagger-ui .opblock .opblock-section-header h1 {
+.swagger-ui .opblock .opblock-section-header h3 {
+  color: var(--black-400);
+  font-family: sans-serif;
   font-size: 16px;
+  flex: 1;
+  margin: 0;
 }
 
 .swagger-ui .opblock .body-param {
@@ -856,7 +860,6 @@
 .swagger-ui .opblock-body .live-responses-table .response-col_status  {
   display: flex;
   text-align: center;
-  padding-left: 30px;
 }
 .swagger-ui .opblock-body .live-responses-table .response-col_status:empty {
   display: none;
@@ -886,7 +889,7 @@
   display: none;
 }
 
-.swagger-ui .opblock-body .responses-table .response-col_description div > h5{
+.swagger-ui .opblock-body .responses-table .response-col_description div > h5 {
   display: none;
 }
 
@@ -927,6 +930,13 @@
 /* hides the "Responses", "Url", "Server Response" above the example responses hidden by js when live response is active   */
 .swagger-ui .responses-inner > div > h4 {
   display: none;
+}
+
+.swagger-ui .responses-inner h3, .swagger-ui .responses-inner h5 {
+  font-size: 12px;
+  margin: 10px 0 5px;
+  font-family: sans-serif;
+  color: var(--black-400,#3b4151);
 }
 
 .swagger-ui .opblock-body .right-side-wrapper pre span {

--- a/src/styles.css
+++ b/src/styles.css
@@ -729,8 +729,12 @@
   width: 13em;
 }
 
-.swagger-ui .parameters thead {
-  display: none;
+.swagger-ui .parameters thead .parameters-col_description {
+  width: unset;
+}
+
+.swagger-ui .parameters thead .col_header {
+  border-bottom: 1px solid #E6E6E6;
 }
 
 .swagger-ui .parameters .parameters-col_name {


### PR DESCRIPTION
Overwrite some files to correct their heading levels, as they should not be using `h1` tags.

Also includes fix for TDX-2838, adding `scope` to the table headers to identify table columns, as well as displaying the table header