### PR TITLE
chore: upgrade kongponents styling to 8+ (TDX-2888)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^2.0.2",
-    "@kongponents/styles": "^7.2.2",
+    "@kong/kongponents": "^8.32.0",
     "@kyleshockey/xml": "^1.0.2",
     "classnames": "^2.3.2",
     "curl-to-har": "^1.0.1",

--- a/src/kongponents.scss
+++ b/src/kongponents.scss
@@ -1,25 +1,19 @@
-@import "~@kongponents/styles/_variables.scss";
-@import "~@kongponents/styles/forms/_forms.scss";
-@import "~@kongponents/styles/_utils.scss";
+@use "sass:meta";
+@use "sass:map";
+
+// Import Kongponents Sass variables (path may vary)
+@import "~@kong/kongponents/dist/_variables.scss";
 
 :host {
-  // colors
-  @each $name, $color in $colors {
-    // add empty string so dart-sass will properly interpret class name from variable
-    --#{"" + $name}: #{$color};
-  }
-  // Spacings
-  @each $name, $space in $spacing {
-    --spacing-#{$name}: #{$space};
-  }
-  // Type
-  @each $name, $size in $type-sizes {
-    --type-#{$name}: #{$size};
-  }
+  // Include Kongponents CSS Variables mixin from the import above
+  @include kongponents-css-variables;
+
+  // Import Kongponents styles (path may vary)
+  @include meta.load-css("../node_modules/@kong/kongponents/dist/style.css");
 }
 
 @mixin boxShadow($color, $whiteShadowSpred: 2px, $colorShadowSpread: 4px) {
-  box-shadow: 0 0 0 $whiteShadowSpred var(--white, color(white)), 0 0 0 $colorShadowSpread $color;
+  box-shadow: 0 0 0 $whiteShadowSpred var(--white, map.get($colors, 'white')), 0 0 0 $colorShadowSpread $color;
 }
 
 .k-button {
@@ -33,7 +27,7 @@
   line-height: 1.25;
   text-decoration: none;
   vertical-align: middle;
-  color: var(--black-70, color(black-70));
+  color: var(--black-70, map.get($colors,"black-70"));
   border: 1px solid transparent;
   border-radius: var(--KButtonRadius, 3px);
   transition: all .2s ease-in-out;
@@ -117,17 +111,17 @@
   }
   &.primary {
     color: var(--button_colors-primary-text, #fff);
-    background-color: var(--KButtonPrimaryBase, var(--blue-500, color(blue-500)));
+    background-color: var(--KButtonPrimaryBase, var(--blue-500, map.get($colors, 'blue-500')));
     &:hover:not(:disabled) {
       opacity: 0.85;
       background-color: var(--KButtonPrimaryHover, var(--blue-600));
     }
     &:active {
       opacity: 0.5;
-      background-color: var(--KButtonPrimaryActive, var(--blue-600, color(blue-600)));
+      background-color: var(--KButtonPrimaryActive, var(--blue-600, map.get($colors, 'blue-600')));
     }
     &:focus {
-      @include boxShadow(var(--KButtonPrimaryBase, var(--blue-500, color(blue-500))));
+      @include boxShadow(var(--KButtonPrimaryBase, var(--blue-500, map.get($colors, 'blue-500'))));
     }
     &:disabled,
     &[disabled] {
@@ -137,16 +131,16 @@
   }
   &.danger {
     color: var(--white, #fff);
-    background-color: var(--KButtonDangerBase, var(--red-500, color(red-500)));
+    background-color: var(--KButtonDangerBase, var(--red-500, map.get($colors, 'red-500')));
     &:hover:not(:disabled) {
-      $hover: rgba(color(red-700), .85);
+      $hover: rgba(map.get($colors, 'red-700'), .85);
       background-color: var(--KButtonDangerHover, $hover);
     }
     &:active {
-      background-color: var(--KButtonDangerActive, var(--red-700, color(red-700)));
+      background-color: var(--KButtonDangerActive, var(--red-700, map.get($colors, 'red-700')));
     }
     &:focus {
-      @include boxShadow(var(--KButtonDangerBase, var(--red-700, color(red-700))));
+      @include boxShadow(var(--KButtonDangerBase, var(--red-700, map.get($colors, 'red-700'))));
     }
     &:disabled,
     &[disabled] {
@@ -156,16 +150,16 @@
   }
   &.creation {
     color: var(--white, #fff);
-    background-color: var(--KButtonCreationBase, var(--green-500, color(green-500)));
+    background-color: var(--KButtonCreationBase, var(--green-500, map.get($colors, 'green-500')));
     &:hover:not(:disabled) {
-      $hover: rgba(color(green-600), .85);
+      $hover: rgba(map.get($colors, 'green-600'), .85);
       background-color: var(--KButtonCreationHover, $hover);
     }
     &:active {
-      background-color: var(--KButtonCreationActive, var(--green-600, color(green-600)));
+      background-color: var(--KButtonCreationActive, var(--green-600, map.get($colors, 'green-600')));
     }
     &:focus {
-      @include boxShadow(var(--KButtonCreationBase, var(--green-600, color(green-600))));
+      @include boxShadow(var(--KButtonCreationBase, var(--green-600, map.get($colors, 'green-600'))));
     }
     &:disabled,
     &[disabled] {
@@ -174,18 +168,18 @@
     }
   }
   &.outline {
-    color: var(--KButtonOutlineColor, var(--blue-500, color(blue-500)));
-    border-color: var(--KButtonOutlineBorder, rgba(color(blue-500), .4));
-    background-color: var(--white, color(white));
+    color: var(--KButtonOutlineColor, var(--blue-500, map.get($colors, 'blue-500')));
+    border-color: var(--KButtonOutlineBorder, rgba(map.get($colors, 'blue-500'), .4));
+    background-color: var(--white, map.get($colors, 'white'));
     &:hover:not(:disabled) {
-      border-color: var(--KButtonOutlineHoverBorder, rgba(color(blue-500), 1));
+      border-color: var(--KButtonOutlineHoverBorder, rgba(map.get($colors, 'blue-500'), 1));
     }
     &:active {
-      border-color: var(--KButtonOutlineActiveBorder, rgba(color(blue-500), 1));
-      background-color: var(--KButtonOutlineActive, var(--blue-100, color(blue-100)));
+      border-color: var(--KButtonOutlineActiveBorder, rgba(map.get($colors, 'blue-500'), 1));
+      background-color: var(--KButtonOutlineActive, var(--blue-100, map.get($colors, 'blue-100')));
     }
     &:focus {
-      @include boxShadow(var(--KButtonOutlineBorder, var(--blue-500, color(blue-500))));
+      @include boxShadow(var(--KButtonOutlineBorder, var(--blue-500, map.get($colors, 'blue-500'))));
     }
     &:disabled,
     &[disabled] {
@@ -194,13 +188,13 @@
     }
   }
   &.btn-link {
-    color: var(--KButtonBtnLink, var(--blue-500, color(blue-500)));
+    color: var(--KButtonBtnLink, var(--blue-500, map.get($colors, 'blue-500')));
     background-color: transparent;
     &:hover:not(:disabled) {
       text-decoration: underline;
     }
     &:focus {
-      @include boxShadow(var(--blue-500, color(blue-500)), 0, 2px);
+      @include boxShadow(var(--blue-500, map.get($colors, 'blue-500')), 0, 2px);
     }
     &:disabled,
     &[disabled] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,22 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kongponents/styles@^7.2.2":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@kongponents/styles/-/styles-7.2.2.tgz#33877ca4155fe43229ce40bb52f528685b0114d9"
-  integrity sha512-0x2DMmz8fx/cam7LlKNe/JNAl3Ttt71QuAH1C00zvEGWhxm/ECsCjdgQ+5SnVSHE9B+oS348E6WocJZY0JizwA==
+"@kong/kongponents@^8.32.0":
+  version "8.32.0"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.32.0.tgz#a612b9a363b1393757f174e3fca15d3d55717fa5"
+  integrity sha512-Ed+mJ8hEt02Kc6rwqoH8XGjb9/gUqIl3e7JJ97FrEcBPbaf/2VIsA156PQE0HXxOlzw4LEfQQ2iGoOOy/HB+Og==
+  dependencies:
+    axios "^0.27.2"
+    date-fns "^2.29.3"
+    date-fns-tz "^1.3.7"
+    focus-trap "^7.1.0"
+    focus-trap-vue "^3.4.0"
+    popper.js "^1.15.0"
+    sortablejs "^1.15.0"
+    swrv "^1.0.0"
+    uuid "^8.3.2"
+    v-calendar "^3.0.0-alpha.8"
+    vue-draggable-next "^2.1.1"
 
 "@kyleshockey/xml@^1.0.2":
   version "1.0.2"
@@ -1007,6 +1019,11 @@
   integrity sha512-iMo32MPLcI9cPxs3YL5kmKxKgDmkSZDCFEqIT5eRk7d/Ll8r4X3SwGYSigzALd6+RHWlFEmjL1QyaQ15xDZFlw==
   dependencies:
     stream "^0.0.2"
+
+"@popperjs/core@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
+  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
 
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
@@ -1043,6 +1060,11 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
+"@types/lodash@^4.14.165":
+  version "4.14.191"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
+  integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
 
 "@types/node@*":
   version "18.11.10"
@@ -1288,6 +1310,14 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1752,6 +1782,16 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
+date-fns-tz@^1.0.12, date-fns-tz@^1.3.7:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.8.tgz#083e3a4e1f19b7857fa0c18deea6c2bc46ded7b9"
+  integrity sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==
+
+date-fns@^2.16.1, date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2043,12 +2083,29 @@ focus-trap-react@^10.0.0:
     focus-trap "^7.0.0"
     tabbable "^6.0.0"
 
+focus-trap-vue@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.4.0.tgz#ea63ef2dce04e929bc09e2b3df0e36a058574b82"
+  integrity sha512-VAI4gJgsjC8KcjDH+h4j2SxFY2XrXmm47a1EXti8gx311abybzqVhkS32Um7i+00J8RQD7hqL1Kfc26WpsMx0w==
+
 focus-trap@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.0.0.tgz#4e2cd9aab5b673e2cbad945c52bd232f6160c2cb"
   integrity sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==
   dependencies:
     tabbable "^6.0.0"
+
+focus-trap@^7.1.0:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.3.1.tgz#417c98e5f1ab94e717d31f1bafa2da45dabcd65f"
+  integrity sha512-bX/u4FJ+F0Pp6b/8Q9W8Br/JaLJ7rrhOJAzai9JU8bh4BPdOjEATy4pxHcbBBxFjPN4d1oHy7/KqknEdOetm9w==
+  dependencies:
+    tabbable "^6.1.1"
+
+follow-redirects@^1.14.9:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -2061,6 +2118,15 @@ form-data@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -2558,7 +2624,7 @@ lodash.debounce@^4, lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash@^4.17.4:
+lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2892,6 +2958,11 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+popper.js@^1.15.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
@@ -3359,6 +3430,11 @@ shell-quote@^1.4.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+sortablejs@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.0.tgz#53230b8aa3502bb77a29e2005808ffdb4a5f7e2a"
+  integrity sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -3493,10 +3569,20 @@ swagger2har@1.0.3:
     json-schema-instantiator "0.4.4"
     rollup-plugin-babel "^4.4.0"
 
+swrv@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/swrv/-/swrv-1.0.3.tgz#b1af4f55a77d74336d29956924cb1b61f564490f"
+  integrity sha512-sl+eLEE+aPPjhP1E8gQ75q3RPRyw5Gd/kROnrTFo3+LkCeLskv7F+uAl5W97wgJkzitobL6FLsRPVm0DgIgN8A==
+
 tabbable@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.0.tgz#7f95ea69134e9335979092ba63866fe67b521b01"
   integrity sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw==
+
+tabbable@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.1.tgz#40cfead5ed11be49043f04436ef924c8890186a0"
+  integrity sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==
 
 tachyons-custom@^4.9.5:
   version "4.9.8"
@@ -3706,6 +3792,27 @@ util@^0.12.5:
     is-generator-function "^1.0.7"
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v-calendar@^3.0.0-alpha.8:
+  version "3.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/v-calendar/-/v-calendar-3.0.0-alpha.8.tgz#3bc8c69f4788fb527c39706f41fd2a502a17c827"
+  integrity sha512-T23H5UbK0EomrwArlF/jrT2LFbV/lu+Bp9JroZ1paN6rPoaMyvE+HrLxvAmUgi+pODrdTURDMzM3+WPgeFKEBQ==
+  dependencies:
+    "@popperjs/core" "2.4.0"
+    "@types/lodash" "^4.14.165"
+    date-fns "^2.16.1"
+    date-fns-tz "^1.0.12"
+    lodash "^4.17.20"
+
+vue-draggable-next@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/vue-draggable-next/-/vue-draggable-next-2.1.1.tgz#49886da82f116d11b3e4df7674320fdacf5d7e04"
+  integrity sha512-f5lmA7t6LMaL4viR7dU30zzvqJzaKQs0ymL0Jy9UDT9uiZ2tXF3MzPzEvpTH2UODXZJkT+SnjeV1fXHMsgXLYA==
 
 watchpack@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Updates the kongponents package, as the old one is going to be deprecated. In order for this to work, had to use `sass:map` in order to get the values from the variables. Otherwise, it wouldn't compile properly.