### PR TITLE
style: add some more styles to support dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -126,6 +126,11 @@
 
   .examples-select-element {
     width: 100%;
+    // to match the other selects
+    height: 44px;
+    background-color: var(--KInputBackground, field);
+    border-color: var(--KInputBorder, transparent);
+    color: var(--text_colors-primary, inherit);
   }
 
   &__section-label {
@@ -381,7 +386,7 @@
 
   li {
     font-size: 12px;
-
+    margin-bottom: 4px;
     min-width: 60px;
     padding: 0;
 
@@ -417,8 +422,7 @@
       background: none;
       border: 0;
       padding: 0;
-
-      color: inherit;
+      color: var(--text_colors-primary, inherit);
       font-family: inherit;
       font-weight: inherit;
     }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -506,7 +506,7 @@
   font-weight: 600;
   font-size: var(--type-md);
   padding-bottom: var(--spacing-lg);
-  border-bottom: 2px solid var(--black-10);
+  border-bottom: 2px solid var(--section_colors-stroke, var(--black-10, rgba(0, 0, 0, 0.1)));
   margin-top: var(--spacing-md);
 }
 
@@ -724,7 +724,6 @@
   font-size: 13px;
   font-weight: normal;
   color: var(--text_colors-secondary);
-  opacity: 0.45;
 }
 
 .swagger-ui .parameters .parameters-col_name .prop-format {


### PR DESCRIPTION
Fixes the coloring for a border, as well as making sure the select is consistent with other input fields.

<img width="658" alt="Screenshot 2023-03-08 at 12 01 01 PM" src="https://user-images.githubusercontent.com/40131297/223810733-77c83eaa-9ed3-4c22-b24c-736c637eb239.png">
<img width="797" alt="Screenshot 2023-03-08 at 12 00 58 PM" src="https://user-images.githubusercontent.com/40131297/223810748-470830b4-04b6-4eff-9fce-15f8824b7c17.png">
