### PR TITLE
style: update styles to address the code snippet widget (TDX-2985)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -128,8 +128,8 @@
     width: 100%;
     // to match the other selects
     height: 44px;
-    background-color: var(--KInputBackground, field);
-    border-color: var(--KInputBorder, transparent);
+    background-color: var(--KInputBackground, var(--grey-100, #f8f8fa));
+    border-color: var(--KInputBorder, var(--select-border-color));
     color: var(--text_colors-primary, inherit);
   }
 
@@ -425,6 +425,17 @@
       color: var(--text_colors-primary, inherit);
       font-family: inherit;
       font-weight: inherit;
+    }
+  }
+}
+
+.opblock-description-wrapper {
+  .examples-select {
+    margin: var(--spacing-sm, 12px) 0 0;
+    display: inline-block;
+  
+    .examples-select-element {
+      margin-top: var(--spacing-xs, 8px);
     }
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -62,8 +62,8 @@
 
 // theme all selects colors
 .swagger-ui select {
-  background-image: linear-gradient(45deg, transparent 50%, var(--text_colors-accent) 50%),
-    linear-gradient(135deg, var(--text_colors-accent) 50%, transparent 50%);
+  background-image: linear-gradient(45deg, transparent 50%, var(--text_colors-accent, #07A88D) 50%),
+    linear-gradient(135deg, var(--text_colors-accent, #07A88D) 50%, transparent 50%);
   background-position: calc(100% - 20px) calc(1em + 2px), calc(100% - 15px) calc(1em + 2px);
   background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
@@ -765,8 +765,8 @@
 }
 
 .swagger-ui .opblock-body .responses-wrapper pre {
-  background-color: var(--section_colors-accent) !important;
-  color: var(--text_colors-primary) !important;
+  background-color: var(--section_colors-accent, rgb(51, 51, 51)) !important;
+  color: var(--text_colors-primary, #fff) !important;
 }
 
 .swagger-ui .swagger-ui .responses-table {
@@ -1060,6 +1060,7 @@
 .swagger-ui .code-snippet {
   position: relative;
   margin-top: var(--spacing-md);
+  color: #fff;
 }
 
 .swagger-ui .code-snippet .overlay {
@@ -1134,16 +1135,6 @@
   padding: var(--spacing-xs, 8px);
   background-color: rgb(0, 36, 61);
   overflow-x: auto;
-}
-
-.swagger-ui .code-snippet .tabs-component-panels > section > pre span :before {
-  counter-increment: line;
-  content: counter(line);
-  display: inline-block;
-  border-right: 1px solid #ddd;
-  padding: 0 0.5em;
-  margin-right: 0.5em;
-  color: #888;
 }
 
 .swagger-ui .parameters-col_description {


### PR DESCRIPTION
- Sets a hardcoded white text as an intermediate fix for the contrast issues on the code snippet widget
- fix some spacing with the `examples-select` select
- remove the pre styling which added random line numbers in the middle of lines of code (e.g. when looking at ruby examples)