### PR TITLE
fix(codesnippet): support relative url in server object

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -525,3 +525,17 @@ export const isEmptyValue = (value) => {
 
   return false
 }
+
+export const toAbsoluteUrl = (url, baseURL) => {
+  if (/^[a-z]+:\/\//i.test(url)) {
+    return url
+  }
+
+  if (url.startsWith('//')) {
+    return `${window.location.protocol}${url}`
+  }
+
+  return /^[a-z]+:\/\//i.test(baseURL)
+    ? new URL(url, baseURL).href
+    : new URL(url, window.location.href).href
+}


### PR DESCRIPTION
Per https://swagger.io/specification/v3/, the `url` field in server object could be relative. But the `request.url` in har should not be relative.

To fix this, a `toAbsoluteUrl` was added to convert the relative url in spec file to qualified absolute URL

This fix FTI-4899