### PR TITLE
chore: bump version to remove console log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.1.9",
+  "version": "4.2.0",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
The dist files have a console log that is junk, so this PR bumps package so that we can publish a new package version without this log.