### PR TITLE
style: update servers container text color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/_servers.scss
+++ b/src/styles/_servers.scss
@@ -1,4 +1,6 @@
 .servers {
+  color: var(--text_colors-primary, var(--black-70, rgba(0, 0, 0, 0.7)));
+  
   > label {
     font-size: 12px;
 


### PR DESCRIPTION
<img width="817" alt="Screenshot 2023-06-21 at 1 20 22 PM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/e1f591cc-ff2b-4509-a677-ff488b4aefff">

Applies theme coloring to the servers text, specifically in the case of dark mode / custom themes.e