### PR TITLE
style: adjust servers text spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -62,7 +62,7 @@
   font-size: var(--type-sm, 14px);
   color: var(--text_colors-primary, var(--black-70, rgba(0, 0, 0, 0.7)));
   display: inline-block;
-  margin-right: var(--spacing-md);
+  margin-bottom: var(--spacing-sm, 12px);
 }
 
 .schemes-wrapper :global label {

--- a/src/styles/_servers.scss
+++ b/src/styles/_servers.scss
@@ -15,6 +15,12 @@
     }
   }
 
+  > div {
+    h4 {
+      margin: var(--spacing-sm, 12px) 0;
+    }
+  }
+
   h4.message {
     padding-bottom: 2em;
   }
@@ -38,12 +44,13 @@
       input {
         width: 100%;
         height: 100%;
+        margin: 0;
       }
     }
   }
 
   .computed-url {
-    margin: 2em 0;
+    margin: var(--spacing-sm, 12px) 0;
 
     code {
       display: inline-block;


### PR DESCRIPTION
<img width="571" alt="Screenshot 2023-06-22 at 7 42 42 AM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/6702da8c-15cc-497c-b258-56e818a0215b">

Adjusts the margin spacing between elements to not take up as much space.