### PR TITLE
style: wrap flex containers for better response styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -711,6 +711,7 @@
 .response-controls {
   padding-top: 1em;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .response-control-media-type {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -819,8 +819,9 @@
   padding: 10px;
   background-color: var(--section_colors-accent);
   border-radius: 0 4px 4px 0;
-  width: 100%;
+  width: unset;
   font-family: monospace;
+  flex-grow: 2;
 }
 
 .swagger-ui .opblock-body .responses-table .response-col_description > div {
@@ -854,6 +855,7 @@
   border-radius: 4px;
   border-bottom: 30px solid transparent;
   font-family: monospace;
+  flex-wrap: wrap;
 
   .response-col_links {
     display: none;


### PR DESCRIPTION
Before
<img width="361" alt="Screenshot 2023-07-12 at 12 12 48 PM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/9f51f278-ff9e-474c-9ea2-b115351f30be">

After
<img width="428" alt="Screenshot 2023-07-12 at 12 13 42 PM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/c8f7f4ac-f495-4f23-9405-ac6f56b8b507">
