### PR TITLE
fix: properly display authorize btn (TDX-3426)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/swagger-ui-kong-theme-universal",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "SwaggerUI theme for Kong Portal and Konnect Portal",
   "main": "dist/main.js",
   "scripts": {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -942,6 +942,7 @@
 .swagger-ui .opblock .opblock-summary-control {
   grid-column-start: 1;
   grid-column-end: 4;
+  grid-row-start: 1;
 
   .arrow {
     grid-row-start: 1;
@@ -983,7 +984,17 @@
 }
 
 .swagger-ui .opblock .opblock-summary .authorization__btn {
-  display: none;
+  padding-left: 0;
+  grid-row-start: 1;
+  grid-column-start: 3;
+  position: relative;
+  right: 30px;
+  top: -20px;
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
 }
 
 .swagger-ui .opblock .opblock-summary .opblock-summary-path,


### PR DESCRIPTION
# Summary
This fixes the authorize button to display properly

## Before 

<img width="696" alt="Screenshot 2023-09-21 at 4 02 34 PM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/456f2000-d641-410b-ac03-71a5d5193f4a">

## After

<img width="736" alt="Screenshot 2023-09-21 at 4 02 39 PM" src="https://github.com/Kong/swagger-ui-kong-theme/assets/40131297/ab2e8f9e-bd7b-4c96-ade3-bbf20e4317cd">
