### PR TITLE
fix: a11y DOM structure improvements and text input auto trim

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -7,7 +7,16 @@ import React, { Component } from "react"
 import PropTypes from "prop-types"
 
 const NoMargin = ({ children, id, labelledBy }) => {
-  return <div id={id} aria-labelledby={labelledBy} style={{ height: "auto", border: "none", margin: 0, padding: 0 }}> {children} </div>
+  return (
+    <div
+      id={id}
+      role="region"
+      aria-labelledby={labelledBy}
+      style={{ height: "auto", border: "none", margin: 0, padding: 0 }}
+    >
+      { children }
+    </div>
+  )
 }
 
 NoMargin.propTypes = {

--- a/src/components/Models.js
+++ b/src/components/Models.js
@@ -48,8 +48,10 @@ export default class Models extends Component {
 
     return <section className={showModels ? "models is-open" : "models"}>
       <button
+        id="operations-models"
         className="btn"
         type="button"
+        aria-controls="operations-models-collapse"
         aria-label={showModels ? `Collapse ${isOAS3 ? "Schemas" : "Models"}` : `Expand ${isOAS3 ? "Schemas" : "Models"}`}
         aria-expanded={showModels}
         onClick={() => layoutActions.show("models", !showModels)}
@@ -62,7 +64,7 @@ export default class Models extends Component {
         </div>
 
       </button>
-      <Collapse isOpened={showModels}>
+      <Collapse isOpened={showModels} id="operations-models-collapse" labelledBy="operations-models">
         {
           definitions.entrySeq().map(([name]) => {
 

--- a/src/components/Operation.js
+++ b/src/components/Operation.js
@@ -14,7 +14,6 @@ export default class Operation extends PureComponent {
     response: null,
     request: null,
     specPath: List(),
-    summary: ""
   }
 
   render() {
@@ -39,6 +38,7 @@ export default class Operation extends PureComponent {
     let operationProps = this.props.operation
 
     let {
+      summary,
       deprecated,
       isShown,
       path,
@@ -64,6 +64,7 @@ export default class Operation extends PureComponent {
     let operationScheme = specSelectors.operationScheme(path, method)
     let isShownKey = ["operations", tag, operationId]
     let extensions = getExtensions(operation)
+    summary = summary || operation.get("summary")
 
     const Responses = getComponent("responses")
     const Parameters = getComponent( "parameters" )
@@ -87,13 +88,22 @@ export default class Operation extends PureComponent {
 
     let onChangeKey = [ path, method ] // Used to add values to _this_ operation ( indexed by path and method )
 
+    const id = escapeDeepLinkPath(isShownKey.join("-"))
+    const headerId = id + '-header'
+    const panelId = id + '-collapse'
+    const summaryAria = isShown
+      ? { controls: panelId, label: `Collapse ${operationId} (${ summary ? summary : tag }) operation block` }
+      : { label: `Expand ${operationId} (${ summary ? summary : tag }) operation block` }
+
     return (
       <div
         className={deprecated ? "opblock opblock-deprecated" : isShown ? `opblock opblock-${method} is-open` : `opblock opblock-${method}`}
         tabIndex={0}
-        id={escapeDeepLinkPath(isShownKey.join("-"))}
+        id={id}
       >
         <OperationSummary
+          id={headerId}
+          aria={summaryAria}
           operationProps={operationProps}
           toggleShown={toggleShown}
           getComponent={getComponent}
@@ -101,7 +111,7 @@ export default class Operation extends PureComponent {
           authSelectors={authSelectors}
           specPath={specPath}
         />
-        <Collapse isOpened={isShown}>
+        <Collapse isOpened={isShown} id={panelId} labelledBy={headerId}>
           <div className="opblock-body">
             { (operation && operation.size) || operation === null ? null :
               <img height={"32px"} width={"32px"} src={require("../img/rolling-load.svg")} className="opblock-loading-animation" />

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -69,6 +69,31 @@ export default class ParameterRow extends Component {
     this.setDefaultValue()
   }
 
+  // kong changes - trim string values
+  trimStringValues = () => {
+    const config = this.props.getConfigs()
+    if (config.theme.enableFormInputAutoTrim) {
+      setTimeout(() => {
+        const { rawParam, onChange, specSelectors, pathMethod } = this.props
+        const paramWithMeta = specSelectors.parameterWithMetaByIdentity(pathMethod, rawParam) || Map()
+        const value = paramWithMeta ? paramWithMeta.get("value") : ""
+        const trimmed = this.trimStringValuesRecursively(value)
+        onChange(rawParam, trimmed)
+      }, 0)
+    }
+  }
+
+  trimStringValuesRecursively = (value) => {
+    if (List.isList(value)) {
+      return value.map(v => this.trimStringValuesRecursively(v))
+    } else if (Map.isMap(value)) {
+      return value.mapEntries(([k, v]) => [k, this.trimStringValuesRecursively(v)])
+    } else if (typeof value === "string") {
+      return value.trim()
+    }
+    return value
+  }
+
   onChangeWrapper = (value, isXml = false) => {
     let { onChange, rawParam } = this.props
     let valueForUpstream
@@ -330,6 +355,7 @@ export default class ParameterRow extends Component {
               disabled={!isExecute}
               description={param.get("description") ? `${param.get("name")} - ${param.get("description")}` : `${param.get("name")}`}
               onChange={this.onChangeWrapper}
+              onTextInputBlur={this.trimStringValues}
               errors={paramWithMeta.get("errors")}
               schema={schema} />
           }

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -152,10 +152,23 @@ export default class SidebarList extends React.Component {
     const FilterContainer = this.props.getComponent("FilterContainer", true)
 
     return (
-      <div className="spec sidebar-list" id="spec-sidebar-list">
+      <nav
+        aria-label="Resources navigation"
+        className="spec sidebar-list"
+        id="spec-sidebar-list"
+      >
+        <h2 className="spec list-title">Resources</h2>
+
+        <FilterContainer className='sidebar-filter' />
+
+        { this.renderResourcesList() }
+      </nav>
+    )
+  }
+
+  renderResourcesList() {
+    return (
         <ul>
-          <li role="none" className="spec list-title">Resources</li>
-          <li role="none"><FilterContainer /></li>
           {this.state.filteredSidebarData.map((sidebarItem, tag) =>
             <li className={"submenu" + this.ifActive(this.isTagActive(tag))} >
               <span
@@ -193,7 +206,6 @@ export default class SidebarList extends React.Component {
             </li>)}
 
         </ul>
-      </div>
     )
   }
 }

--- a/src/containers/Filter.js
+++ b/src/containers/Filter.js
@@ -25,7 +25,7 @@ export default class FilterContainer extends React.Component {
     if (isLoading) inputStyle.color = "#aaa"
 
     return (
-      <div>
+      <div className={ this.props.className }>
         {filter === null || filter === false ? null :
           <div className="filter-container">
             <Col className="filter wrapper" mobile={12}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,13 +91,14 @@
 #sidebar #spec-sidebar {
   padding-bottom: 100px;
 }
-#sidebar .sidebar-list li.list-title {
+#sidebar .sidebar-list .spec.list-title {
   font-weight: bold;
   color: #262626;
   font-size: 16px;
-}
-#sidebar .sidebar-list li.spec.list-title {
-  padding-left: 1.8rem;
+  padding: 0.3rem 0.2rem 0.3rem 1.8rem;
+  font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
+  margin-bottom: 1rem;
+  line-height: 1.6;
 }
 #sidebar .sidebar-list {
   padding: 0;
@@ -106,6 +107,10 @@
 }
 #sidebar .sidebar-list.info {
   padding-left: 1.8rem;
+}
+#sidebar .sidebar-filter {
+  padding: 0.3rem 0.2rem 0.3rem 0;
+  margin-bottom: 1rem;
 }
 #sidebar .filter-container input{
   width: 200px;


### PR DESCRIPTION
the text input auto trim function is not enabled by default, customer who requests this function can manually set `swaggerUIOptions.theme.enableFormInputAutoTrim` to `true` to enable this feature.

this fix FTI-5334