### PR TITLE
fix: catch `toAbsoluteUrl` in dev portal editor preview

### DIFF
--- a/src/components/AugmentingResponses.js
+++ b/src/components/AugmentingResponses.js
@@ -69,7 +69,11 @@ export default class AugmentingResponses extends React.Component {
     if (specSelectors.isOAS3()) {
       const selectedServer = system.oas3Selectors.selectedServer()
       const specUrl = specSelectors.url()
-      baseURL = toAbsoluteUrl(selectedServer, specUrl)
+      try {
+        baseURL = toAbsoluteUrl(selectedServer, specUrl)
+      } catch { // failed to get window location, most likely in iframe preview
+        baseURL = 'http://example.com'
+      }
       if (path.startsWith('/') && baseURL.endsWith('/')) {
         baseURL = baseURL.slice(0, -1)  // workaround for swagger2har path concatenate bug
       }


### PR DESCRIPTION
The preview page in KM's portal editor is wrapped in a `<iframe />` and use `srcDoc` to provide content, and `location.href` will be `about:srcdoc` in this situation, leading uncaughted error when executing `new URL('', window.location.href)`

To fix this, we catch the error and use `http://example.com` as fallback base url

This fix FTI-5069