### PR TITLE
fix(a11y): correct tab-index and add aria invalid/describedby support

### DIFF
--- a/src/components/HighlightCode.js
+++ b/src/components/HighlightCode.js
@@ -52,6 +52,7 @@ export default class HighlightCode extends Component {
         { !downloadable ? null :
           <div
             role="button"
+            tabIndex={0}
             aria-label="download contents"
             className="download-contents"
             onClick={this.downloadText}
@@ -63,7 +64,7 @@ export default class HighlightCode extends Component {
           ref={this.initializeComponent}
           onWheel={this.preventYScrollingBeyondElement}
           className={className + " microlight"}
-          tabIndex="0">
+        >
           {value}
         </pre>
       </div>

--- a/src/components/ParameterRow.js
+++ b/src/components/ParameterRow.js
@@ -357,12 +357,13 @@ export default class ParameterRow extends Component {
               onChange={this.onChangeWrapper}
               onTextInputBlur={this.trimStringValues}
               errors={paramWithMeta.get("errors")}
+              errorsDescribedById={`param-row-${param.get("name")}-errors`}
               schema={schema} />
           }
 
           {/* Kong change -  Display error message in case of errors */}
           {bodyParam ? null
-            : <ParameterRowError errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
+            : <ParameterRowError id={`param-row-${param.get("name")}-errors`} errors={this.getParameterRowErrorProps(paramWithMeta.get("errors"))} param={paramWithMeta.toJS()} />
           }
 
           {

--- a/src/components/custom/ParameterRowError.js
+++ b/src/components/custom/ParameterRowError.js
@@ -37,12 +37,13 @@ export class ParameterRowError extends Component {
   }
 
   render() {
-    const { errors, param } = this.props
+    const { id, errors, param } = this.props
     const associatedInput = this.el?.closest('table.parameters')?.querySelector('input.invalid')
 
 
     return (
       <div
+        id={ id }
         className='parameter-row-error'
         tabIndex='-1'
         ref={this.initializeComponent}
@@ -61,6 +62,7 @@ export class ParameterRowError extends Component {
 }
 
 ParameterRowError.propTypes = {
+  id: PropTypes.string,
   errors: PropTypes.arrayOf(PropTypes.string),
 }
 


### PR DESCRIPTION
correct the usage of the `tab-index` attribute and enable `errorsDescriedById` support

this fix FTI-5660