### PR TITLE
feat: add custom component for op-summary-path

### DIFF
--- a/src/components/OperationSummaryPath.jsx
+++ b/src/components/OperationSummaryPath.jsx
@@ -1,0 +1,54 @@
+import React, { PureComponent } from "react"
+import PropTypes from "prop-types"
+import { Iterable } from "immutable"
+import { createDeepLinkPath } from "core/utils"
+import ImPropTypes from "react-immutable-proptypes"
+
+export default class OperationSummaryPath extends PureComponent{
+
+  static propTypes = {
+    specPath: ImPropTypes.list.isRequired,
+    operationProps: PropTypes.instanceOf(Iterable).isRequired,
+    getComponent: PropTypes.func.isRequired,
+  }
+
+  render(){
+    let {
+      getComponent,
+      operationProps,
+    } = this.props
+
+
+    let {
+      deprecated,
+      isShown,
+      path,
+      tag,
+      operationId,
+      isDeepLinkingEnabled,
+    } = operationProps.toJS()
+
+    /**
+     * Add <wbr> word-break elements between each segment, before the slash
+     * to allow browsers an opportunity to break long paths into sensible segments.
+     */
+    const pathParts = path.split(/(?=\/)/g)
+    for (let i = 1; i < pathParts.length; i += 2) {
+      pathParts.splice(i, 0, <wbr key={i} />)
+    }
+
+    const DeepLink = getComponent( "DeepLink" )
+
+    return(
+      <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" }
+        data-path={path} title={`${tag}/${operationId}`}>
+        <DeepLink
+            enabled={isDeepLinkingEnabled}
+            isShown={isShown}
+            path={createDeepLinkPath(`${tag}/${operationId}`)}
+            text={pathParts} />
+      </span>
+
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import AuthorizeBtn from './components/AuthorizeBtn'
 import './kongponents.scss'
 import './index.css'
 import './styles/main.scss'
+import OperationSummaryPath from './components/OperationSummaryPath'
 
 // Overwriting requires lowercase versions of the react components in swagger-ui
 const SwaggerUIKongTheme = () => {
@@ -20,6 +21,7 @@ const SwaggerUIKongTheme = () => {
       Button,
       Filter,
       KongLayout,
+      OperationSummaryPath,
       Sidebar,
       SidebarList,
       authorizeBtn: AuthorizeBtn,


### PR DESCRIPTION
This is so that when hovering, you can see the whole operation tag. This is not semantic HTML in the slightest already, so I didn't see harm in adding some non-standard tags to get the desired behavior.